### PR TITLE
refactor(build): improve Makefile setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.15
       - name: Check if mods are tidy
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.15
       - name: Produce coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .envrc*
 /coverage.out
 bin/*
+tools/*


### PR DESCRIPTION
There's no need for a bootstrap target anymore, tool targets correctly
detect if they need to do anything or not. Meaning lint target will
automatically fetch relevant tools if needed, and if not, do nothing.