### PR TITLE
refactor(client): rename *Resource objects to *Client

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -31,19 +31,19 @@ type certificatesResponseBody struct {
 	Certificates []*Certificate `json:"certificates,omitempty"`
 }
 
-type CertificatesResource struct {
+type CertificatesClient struct {
 	client   *apiClient
 	basePath *url.URL
 }
 
-func newCertificatesResource(c *apiClient) *CertificatesResource {
-	return &CertificatesResource{
+func newCertificatesClient(c *apiClient) *CertificatesClient {
+	return &CertificatesClient{
 		client:   c,
 		basePath: &url.URL{Path: "/core/v1/"},
 	}
 }
 
-func (s CertificatesResource) List(
+func (s CertificatesClient) List(
 	ctx context.Context,
 	orgID string,
 	opts *ListOptions,
@@ -59,7 +59,7 @@ func (s CertificatesResource) List(
 	return body.Certificates, resp, err
 }
 
-func (s CertificatesResource) Get(
+func (s CertificatesClient) Get(
 	ctx context.Context,
 	id string,
 ) (*Certificate, *Response, error) {
@@ -69,7 +69,7 @@ func (s CertificatesResource) Get(
 	return body.Certificate, resp, err
 }
 
-func (s *CertificatesResource) doRequest(
+func (s *CertificatesClient) doRequest(
 	ctx context.Context,
 	method string,
 	u *url.URL,

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -71,7 +71,7 @@ func Test_certificatesResponseBody_JSONMarshaling(t *testing.T) {
 	}
 }
 
-func TestCertificatesResource_List(t *testing.T) {
+func TestCertificatesClient_List(t *testing.T) {
 	// Correlates to fixtures/certificates_list*.json
 	certificateList := []*Certificate{
 		{
@@ -251,7 +251,7 @@ func TestCertificatesResource_List(t *testing.T) {
 	}
 }
 
-func TestCertificatesResource_Get(t *testing.T) {
+func TestCertificatesClient_Get(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		id  string

--- a/client.go
+++ b/client.go
@@ -20,13 +20,13 @@ type HTTPClient interface {
 type Client struct {
 	apiClient *apiClient
 
-	Certificates           *CertificatesResource
-	DNSZones               *DNSZonesResource
-	DataCenters            *DataCentersResource
-	Networks               *NetworksResource
-	Organizations          *OrganizationsResource
-	VirtualMachinePackages *VirtualMachinePackagesResource
-	VirtualMachines        *VirtualMachinesResource
+	Certificates           *CertificatesClient
+	DNSZones               *DNSZonesClient
+	DataCenters            *DataCentersClient
+	Networks               *NetworksClient
+	Organizations          *OrganizationsClient
+	VirtualMachinePackages *VirtualMachinePackagesClient
+	VirtualMachines        *VirtualMachinesClient
 }
 
 func NewClient(httpClient HTTPClient) *Client {
@@ -45,13 +45,13 @@ func NewClient(httpClient HTTPClient) *Client {
 
 	return &Client{
 		apiClient:              c,
-		Certificates:           newCertificatesResource(c),
-		DNSZones:               newDNSZonesResource(c),
-		DataCenters:            newDataCentersResource(c),
-		Networks:               newNetworksResource(c),
-		Organizations:          newOrganizationsResource(c),
-		VirtualMachinePackages: newVirtualMachinePackagesResource(c),
-		VirtualMachines:        newVirtualMachinesResource(c),
+		Certificates:           newCertificatesClient(c),
+		DNSZones:               newDNSZonesClient(c),
+		DataCenters:            newDataCentersClient(c),
+		Networks:               newNetworksClient(c),
+		Organizations:          newOrganizationsClient(c),
+		VirtualMachinePackages: newVirtualMachinePackagesClient(c),
+		VirtualMachines:        newVirtualMachinesClient(c),
 	}
 }
 

--- a/data_center.go
+++ b/data_center.go
@@ -18,19 +18,19 @@ type dataCentersResponseBody struct {
 	DataCenters []*DataCenter `json:"data_centers,omitempty"`
 }
 
-type DataCentersResource struct {
+type DataCentersClient struct {
 	client   *apiClient
 	basePath *url.URL
 }
 
-func newDataCentersResource(c *apiClient) *DataCentersResource {
-	return &DataCentersResource{
+func newDataCentersClient(c *apiClient) *DataCentersClient {
+	return &DataCentersClient{
 		client:   c,
 		basePath: &url.URL{Path: "/core/v1/"},
 	}
 }
 
-func (s *DataCentersResource) List(
+func (s *DataCentersClient) List(
 	ctx context.Context,
 ) ([]*DataCenter, *Response, error) {
 	u := &url.URL{Path: "data_centers"}
@@ -39,7 +39,7 @@ func (s *DataCentersResource) List(
 	return body.DataCenters, resp, err
 }
 
-func (s *DataCentersResource) Get(
+func (s *DataCentersClient) Get(
 	ctx context.Context,
 	id string,
 ) (*DataCenter, *Response, error) {
@@ -49,7 +49,7 @@ func (s *DataCentersResource) Get(
 	return body.DataCenter, resp, err
 }
 
-func (s *DataCentersResource) GetByPermalink(
+func (s *DataCentersClient) GetByPermalink(
 	ctx context.Context,
 	permalink string,
 ) (*DataCenter, *Response, error) {
@@ -61,7 +61,7 @@ func (s *DataCentersResource) GetByPermalink(
 	return body.DataCenter, resp, err
 }
 
-func (s *DataCentersResource) doRequest(
+func (s *DataCentersClient) doRequest(
 	ctx context.Context,
 	method string,
 	u *url.URL,

--- a/data_center_test.go
+++ b/data_center_test.go
@@ -63,7 +63,7 @@ func Test_dataCentersResponseBody_JSONMarshaling(t *testing.T) {
 	}
 }
 
-func TestDataCentersResource_List(t *testing.T) {
+func TestDataCentersClient_List(t *testing.T) {
 	type args struct {
 		ctx context.Context
 	}
@@ -152,7 +152,7 @@ func TestDataCentersResource_List(t *testing.T) {
 	}
 }
 
-func TestDataCentersResource_Get(t *testing.T) {
+func TestDataCentersClient_Get(t *testing.T) {
 	// Correlates to fixtures/data_center_get.json
 	dataCenter := &DataCenter{
 		ID:        "loc_a2417980b9874c0",
@@ -247,7 +247,7 @@ func TestDataCentersResource_Get(t *testing.T) {
 	}
 }
 
-func TestDataCentersResource_GetByPermalink(t *testing.T) {
+func TestDataCentersClient_GetByPermalink(t *testing.T) {
 	// Correlates to fixtures/data_center_get.json
 	dataCenter := &DataCenter{
 		ID:        "loc_a2417980b9874c0",

--- a/dns_zone.go
+++ b/dns_zone.go
@@ -47,19 +47,19 @@ type dnsZoneResponseBody struct {
 	VerificationDetails *DNSZoneVerificationDetails `json:"details,omitempty"`
 }
 
-type DNSZonesResource struct {
+type DNSZonesClient struct {
 	client   *apiClient
 	basePath *url.URL
 }
 
-func newDNSZonesResource(c *apiClient) *DNSZonesResource {
-	return &DNSZonesResource{
+func newDNSZonesClient(c *apiClient) *DNSZonesClient {
+	return &DNSZonesClient{
 		client:   c,
 		basePath: &url.URL{Path: "/core/v1/"},
 	}
 }
 
-func (s *DNSZonesResource) List(
+func (s *DNSZonesClient) List(
 	ctx context.Context,
 	orgID string,
 	opts *ListOptions,
@@ -75,7 +75,7 @@ func (s *DNSZonesResource) List(
 	return body.DNSZones, resp, err
 }
 
-func (s *DNSZonesResource) Get(
+func (s *DNSZonesClient) Get(
 	ctx context.Context,
 	id string,
 ) (*DNSZone, *Response, error) {
@@ -85,7 +85,7 @@ func (s *DNSZonesResource) Get(
 	return body.DNSZone, resp, err
 }
 
-func (s *DNSZonesResource) GetByName(
+func (s *DNSZonesClient) GetByName(
 	ctx context.Context,
 	name string,
 ) (*DNSZone, *Response, error) {
@@ -97,7 +97,7 @@ func (s *DNSZonesResource) GetByName(
 	return body.DNSZone, resp, err
 }
 
-func (s *DNSZonesResource) Create(
+func (s *DNSZonesClient) Create(
 	ctx context.Context,
 	orgID string,
 	zone *DNSZoneArguments,
@@ -120,7 +120,7 @@ func (s *DNSZonesResource) Create(
 	return body.DNSZone, resp, err
 }
 
-func (s *DNSZonesResource) Delete(
+func (s *DNSZonesClient) Delete(
 	ctx context.Context,
 	id string,
 ) (*DNSZone, *Response, error) {
@@ -130,7 +130,7 @@ func (s *DNSZonesResource) Delete(
 	return body.DNSZone, resp, err
 }
 
-func (s *DNSZonesResource) VerificationDetails(
+func (s *DNSZonesClient) VerificationDetails(
 	ctx context.Context,
 	id string,
 ) (*DNSZoneVerificationDetails, *Response, error) {
@@ -140,7 +140,7 @@ func (s *DNSZonesResource) VerificationDetails(
 	return body.VerificationDetails, resp, err
 }
 
-func (s *DNSZonesResource) Verify(
+func (s *DNSZonesClient) Verify(
 	ctx context.Context,
 	id string,
 ) (*DNSZone, *Response, error) {
@@ -150,7 +150,7 @@ func (s *DNSZonesResource) Verify(
 	return body.DNSZone, resp, err
 }
 
-func (s *DNSZonesResource) UpdateTTL(
+func (s *DNSZonesClient) UpdateTTL(
 	ctx context.Context,
 	id string,
 	ttl int,
@@ -162,7 +162,7 @@ func (s *DNSZonesResource) UpdateTTL(
 	return body.DNSZone, resp, err
 }
 
-func (s *DNSZonesResource) doRequest(
+func (s *DNSZonesClient) doRequest(
 	ctx context.Context,
 	method string,
 	u *url.URL,

--- a/dns_zone_test.go
+++ b/dns_zone_test.go
@@ -214,7 +214,7 @@ func Test_dnsZoneResponseBody_JSONMarshaling(t *testing.T) {
 	}
 }
 
-func TestDNSZonesResource_List(t *testing.T) {
+func TestDNSZonesClient_List(t *testing.T) {
 	// Correlates to fixtures/dns_zones_list*.json
 	dnsZonesList := []*DNSZone{
 		{
@@ -405,7 +405,7 @@ func TestDNSZonesResource_List(t *testing.T) {
 	}
 }
 
-func TestDNSZonesResource_Get(t *testing.T) {
+func TestDNSZonesClient_Get(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		id  string
@@ -487,7 +487,7 @@ func TestDNSZonesResource_Get(t *testing.T) {
 	}
 }
 
-func TestDNSZonesResource_GetByName(t *testing.T) {
+func TestDNSZonesClient_GetByName(t *testing.T) {
 	type args struct {
 		ctx  context.Context
 		name string
@@ -572,7 +572,7 @@ func TestDNSZonesResource_GetByName(t *testing.T) {
 	}
 }
 
-func TestDNSZonesResource_Create(t *testing.T) {
+func TestDNSZonesClient_Create(t *testing.T) {
 	type reqBodyDetails struct {
 		Name string `json:"name"`
 		TTL  int    `json:"ttl,omitempty"`
@@ -769,7 +769,7 @@ func TestDNSZonesResource_Create(t *testing.T) {
 	}
 }
 
-func TestDNSZonesResource_Delete(t *testing.T) {
+func TestDNSZonesClient_Delete(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		id  string
@@ -851,7 +851,7 @@ func TestDNSZonesResource_Delete(t *testing.T) {
 	}
 }
 
-func TestDNSZonesResource_VerificationDetails(t *testing.T) {
+func TestDNSZonesClient_VerificationDetails(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		id  string
@@ -972,7 +972,7 @@ func TestDNSZonesResource_VerificationDetails(t *testing.T) {
 	}
 }
 
-func TestDNSZonesResource_Verify(t *testing.T) {
+func TestDNSZonesClient_Verify(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		id  string
@@ -1079,7 +1079,7 @@ func TestDNSZonesResource_Verify(t *testing.T) {
 	}
 }
 
-func TestDNSZonesResource_UpdateTTL(t *testing.T) {
+func TestDNSZonesClient_UpdateTTL(t *testing.T) {
 	type reqBody struct {
 		TTL int `json:"ttl"`
 	}

--- a/network.go
+++ b/network.go
@@ -23,19 +23,19 @@ type networksResponseBody struct {
 	VirtualNetworks []*VirtualNetwork `json:"virtual_networks,omitempty"`
 }
 
-type NetworksResource struct {
+type NetworksClient struct {
 	client   *apiClient
 	basePath *url.URL
 }
 
-func newNetworksResource(c *apiClient) *NetworksResource {
-	return &NetworksResource{
+func newNetworksClient(c *apiClient) *NetworksClient {
+	return &NetworksClient{
 		client:   c,
 		basePath: &url.URL{Path: "/core/v1/"},
 	}
 }
 
-func (s *NetworksResource) List(
+func (s *NetworksClient) List(
 	ctx context.Context,
 	orgID string,
 ) ([]*Network, []*VirtualNetwork, *Response, error) {
@@ -48,7 +48,7 @@ func (s *NetworksResource) List(
 	return body.Networks, body.VirtualNetworks, resp, err
 }
 
-func (s *NetworksResource) doRequest(
+func (s *NetworksClient) doRequest(
 	ctx context.Context,
 	method string,
 	u *url.URL,

--- a/network_test.go
+++ b/network_test.go
@@ -83,7 +83,7 @@ func Test_networksResponseBody_JSONMarshaling(t *testing.T) {
 	}
 }
 
-func TestNetworksResource_List(t *testing.T) {
+func TestNetworksClient_List(t *testing.T) {
 	type args struct {
 		ctx   context.Context
 		orgID string

--- a/organization.go
+++ b/organization.go
@@ -34,19 +34,19 @@ type organizationsResponseBody struct {
 	Organizations []*Organization `json:"organizations,omitempty"`
 }
 
-type OrganizationsResource struct {
+type OrganizationsClient struct {
 	client   *apiClient
 	basePath *url.URL
 }
 
-func newOrganizationsResource(c *apiClient) *OrganizationsResource {
-	return &OrganizationsResource{
+func newOrganizationsClient(c *apiClient) *OrganizationsClient {
+	return &OrganizationsClient{
 		client:   c,
 		basePath: &url.URL{Path: "/core/v1/"},
 	}
 }
 
-func (s *OrganizationsResource) List(
+func (s *OrganizationsClient) List(
 	ctx context.Context,
 ) ([]*Organization, *Response, error) {
 	u := &url.URL{Path: "organizations"}
@@ -55,7 +55,7 @@ func (s *OrganizationsResource) List(
 	return body.Organizations, resp, err
 }
 
-func (s *OrganizationsResource) Get(
+func (s *OrganizationsClient) Get(
 	ctx context.Context,
 	id string,
 ) (*Organization, *Response, error) {
@@ -65,7 +65,7 @@ func (s *OrganizationsResource) Get(
 	return body.Organization, resp, err
 }
 
-func (s *OrganizationsResource) GetBySubDomain(
+func (s *OrganizationsClient) GetBySubDomain(
 	ctx context.Context,
 	subDomain string,
 ) (*Organization, *Response, error) {
@@ -77,7 +77,7 @@ func (s *OrganizationsResource) GetBySubDomain(
 	return body.Organization, resp, err
 }
 
-func (s *OrganizationsResource) CreateManaged(
+func (s *OrganizationsClient) CreateManaged(
 	ctx context.Context,
 	parentID string,
 	name string,
@@ -90,7 +90,7 @@ func (s *OrganizationsResource) CreateManaged(
 	return body.Organization, resp, err
 }
 
-func (s *OrganizationsResource) doRequest(
+func (s *OrganizationsClient) doRequest(
 	ctx context.Context,
 	method string,
 	u *url.URL,

--- a/organization_test.go
+++ b/organization_test.go
@@ -98,7 +98,7 @@ func Test_organizationsResponseBody_JSONMarshaling(t *testing.T) {
 	}
 }
 
-func TestOrganizationsResource_List(t *testing.T) {
+func TestOrganizationsClient_List(t *testing.T) {
 	type args struct {
 		ctx context.Context
 	}
@@ -187,7 +187,7 @@ func TestOrganizationsResource_List(t *testing.T) {
 	}
 }
 
-func TestOrganizationsResource_Get(t *testing.T) {
+func TestOrganizationsClient_Get(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		id  string
@@ -284,7 +284,7 @@ func TestOrganizationsResource_Get(t *testing.T) {
 	}
 }
 
-func TestOrganizationsResource_GetBySubDomain(t *testing.T) {
+func TestOrganizationsClient_GetBySubDomain(t *testing.T) {
 	type args struct {
 		ctx       context.Context
 		subDomain string
@@ -388,7 +388,7 @@ func TestOrganizationsResource_GetBySubDomain(t *testing.T) {
 	}
 }
 
-func TestOrganizationsResource_CreateManaged(t *testing.T) {
+func TestOrganizationsClient_CreateManaged(t *testing.T) {
 	type args struct {
 		ctx       context.Context
 		parentID  string

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -38,21 +38,21 @@ type virtualMachinesResponseBody struct {
 	VirtualMachines []*VirtualMachine `json:"virtual_machines,omitempty"`
 }
 
-type VirtualMachinesResource struct {
+type VirtualMachinesClient struct {
 	client   *apiClient
 	basePath *url.URL
 }
 
-func newVirtualMachinesResource(
+func newVirtualMachinesClient(
 	c *apiClient,
-) *VirtualMachinesResource {
-	return &VirtualMachinesResource{
+) *VirtualMachinesClient {
+	return &VirtualMachinesClient{
 		client:   c,
 		basePath: &url.URL{Path: "/core/v1/"},
 	}
 }
 
-func (s VirtualMachinesResource) List(
+func (s VirtualMachinesClient) List(
 	ctx context.Context,
 	orgID string,
 	opts *ListOptions,
@@ -68,7 +68,7 @@ func (s VirtualMachinesResource) List(
 	return body.VirtualMachines, resp, err
 }
 
-func (s VirtualMachinesResource) Get(
+func (s VirtualMachinesClient) Get(
 	ctx context.Context,
 	id string,
 ) (*VirtualMachine, *Response, error) {
@@ -78,7 +78,7 @@ func (s VirtualMachinesResource) Get(
 	return body.VirtualMachine, resp, err
 }
 
-func (s VirtualMachinesResource) GetByFQDN(
+func (s VirtualMachinesClient) GetByFQDN(
 	ctx context.Context,
 	fqdn string,
 ) (*VirtualMachine, *Response, error) {
@@ -90,7 +90,7 @@ func (s VirtualMachinesResource) GetByFQDN(
 	return body.VirtualMachine, resp, err
 }
 
-func (s *VirtualMachinesResource) doRequest(
+func (s *VirtualMachinesClient) doRequest(
 	ctx context.Context,
 	method string,
 	u *url.URL,

--- a/virtual_machine_package.go
+++ b/virtual_machine_package.go
@@ -24,21 +24,21 @@ type virtualMachinePackagesResponseBody struct {
 	VirtualMachinePackages []*VirtualMachinePackage `json:"virtual_machine_packages,omitempty"`
 }
 
-type VirtualMachinePackagesResource struct {
+type VirtualMachinePackagesClient struct {
 	client   *apiClient
 	basePath *url.URL
 }
 
-func newVirtualMachinePackagesResource(
+func newVirtualMachinePackagesClient(
 	c *apiClient,
-) *VirtualMachinePackagesResource {
-	return &VirtualMachinePackagesResource{
+) *VirtualMachinePackagesClient {
+	return &VirtualMachinePackagesClient{
 		client:   c,
 		basePath: &url.URL{Path: "/core/v1/"},
 	}
 }
 
-func (s *VirtualMachinePackagesResource) List(
+func (s *VirtualMachinePackagesClient) List(
 	ctx context.Context,
 	opts *ListOptions,
 ) ([]*VirtualMachinePackage, *Response, error) {
@@ -53,7 +53,7 @@ func (s *VirtualMachinePackagesResource) List(
 	return body.VirtualMachinePackages, resp, err
 }
 
-func (s *VirtualMachinePackagesResource) Get(
+func (s *VirtualMachinePackagesClient) Get(
 	ctx context.Context,
 	id string,
 ) (*VirtualMachinePackage, *Response, error) {
@@ -63,7 +63,7 @@ func (s *VirtualMachinePackagesResource) Get(
 	return body.VirtualMachinePackage, resp, err
 }
 
-func (s *VirtualMachinePackagesResource) GetByPermalink(
+func (s *VirtualMachinePackagesClient) GetByPermalink(
 	ctx context.Context,
 	permalink string,
 ) (*VirtualMachinePackage, *Response, error) {
@@ -75,7 +75,7 @@ func (s *VirtualMachinePackagesResource) GetByPermalink(
 	return body.VirtualMachinePackage, resp, err
 }
 
-func (s *VirtualMachinePackagesResource) doRequest(
+func (s *VirtualMachinePackagesClient) doRequest(
 	ctx context.Context,
 	method string,
 	u *url.URL,

--- a/virtual_machine_package_test.go
+++ b/virtual_machine_package_test.go
@@ -67,7 +67,7 @@ func Test_virtualMachinePackagesResponseBody_JSONMarshaling(t *testing.T) {
 	}
 }
 
-func TestVirtualMachinePackagesResource_List(t *testing.T) {
+func TestVirtualMachinePackagesClient_List(t *testing.T) {
 	// Correlates to fixtures/virtual_machine_packages_list*.json
 	packageList := []*VirtualMachinePackage{
 		{
@@ -216,7 +216,7 @@ func TestVirtualMachinePackagesResource_List(t *testing.T) {
 	}
 }
 
-func TestVirtualMachinePackagesResource_Get(t *testing.T) {
+func TestVirtualMachinePackagesClient_Get(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		id  string
@@ -311,7 +311,7 @@ func TestVirtualMachinePackagesResource_Get(t *testing.T) {
 	}
 }
 
-func TestVirtualMachinePackagesResource_GetByPermalink(t *testing.T) {
+func TestVirtualMachinePackagesClient_GetByPermalink(t *testing.T) {
 	type args struct {
 		ctx       context.Context
 		permalink string

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -98,7 +98,7 @@ func Test_virtualMachinesResponseBody_JSONMarshaling(t *testing.T) {
 	}
 }
 
-func TestVirtualMachinesResource_List(t *testing.T) {
+func TestVirtualMachinesClient_List(t *testing.T) {
 	// Correlates to fixtures/virtual_machines_list*.json
 	virtualMachinesList := []*VirtualMachine{
 		{
@@ -278,7 +278,7 @@ func TestVirtualMachinesResource_List(t *testing.T) {
 	}
 }
 
-func TestVirtualMachinesResource_Get(t *testing.T) {
+func TestVirtualMachinesClient_Get(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		id  string
@@ -382,7 +382,7 @@ func TestVirtualMachinesResource_Get(t *testing.T) {
 	}
 }
 
-func TestVirtualMachinesResource_GetByFQDN(t *testing.T) {
+func TestVirtualMachinesClient_GetByFQDN(t *testing.T) {
 	type args struct {
 		ctx  context.Context
 		fqdn string


### PR DESCRIPTION
This is to avoid conflicts with a number of API responses which have fields
called "resources", "resource_type", etc.