### PR TITLE
ci(github): use cache action to cache Go modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Produce coverage report
         run: make cov-func
 
@@ -45,6 +51,12 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Run tests
         run: make test
         env:


### PR DESCRIPTION
Should speed up CI runs.