### PR TITLE
feat(errors): simple method of including error details as a formatted JSON string

### DIFF
--- a/pkg/katapult/client_test.go
+++ b/pkg/katapult/client_test.go
@@ -33,8 +33,10 @@ var (
 		Detail: json.RawMessage(`{}`),
 	}
 
+	//nolint:lll
 	fixturePermissionDeniedErr = "permission_denied: The authenticated " +
-		"identity is not permitted to perform this action"
+		"identity is not permitted to perform this action -- " +
+		"{\n  \"details\": \"Additional information regarding the reason why permission was denied\"\n}"
 	fixturePermissionDeniedResponseError = &ResponseError{
 		Code: "permission_denied",
 		Description: "The authenticated identity is not permitted to perform " +
@@ -45,8 +47,10 @@ var (
     }`),
 	}
 
+	//nolint:lll
 	fixtureValidationErrorErr = "validation_error: A validation error " +
-		"occurred with the object that was being created/updated/deleted"
+		"occurred with the object that was being created/updated/deleted -- " +
+		"{\n  \"errors\": [\n    \"Failed reticulating 3-dimensional splines\",\n    \"Failed preparing captive simulators\"\n  ]\n}"
 	fixtureValidationErrorResponseError = &ResponseError{
 		Code: "validation_error",
 		Description: "A validation error occurred with the object that was " +

--- a/pkg/katapult/organization_test.go
+++ b/pkg/katapult/organization_test.go
@@ -858,8 +858,10 @@ func TestOrganizationsClient_CreateManaged(t *testing.T) {
 					SubDomain: "nerv",
 				},
 			},
+			//nolint:lll
 			errStr: "validation_error: A validation error occurred with the " +
-				"object that was being created/updated/deleted",
+				"object that was being created/updated/deleted -- " +
+				"{\n  \"errors\": [\n    \"Sub domain has already been taken\"\n  ]\n}",
 			errResp: &ResponseError{
 				Code: "validation_error",
 				Description: "A validation error occurred with the object " +

--- a/pkg/katapult/virtual_machine_build_test.go
+++ b/pkg/katapult/virtual_machine_build_test.go
@@ -23,7 +23,11 @@ var (
 	}
 
 	fixtureInvalidXMLSpecErr = "invalid_spec_xml: The spec XML provided is " +
-		"invalid"
+		"invalid -- " + undent.String(`
+            {
+              "errors": "1:21: FATAL: EndTag: '</' not found"
+            }`,
+	)
 	fixtureInvalidXMLSpecResponseError = &ResponseError{
 		Code:        "invalid_spec_xml",
 		Description: "The spec XML provided is invalid",


### PR DESCRIPTION
Exposes error details as a pretty printed JSON string at the end of error types.

This is a temporary stop-gap before creating unique types for each error that
can happen, which formats the details into text as relevant for each error type.