### PR TITLE
feat(katapult): add New<resource>Lookup() functions

### DIFF
--- a/pkg/katapult/data_center_test.go
+++ b/pkg/katapult/data_center_test.go
@@ -50,6 +50,57 @@ func TestDataCenter_JSONMarshaling(t *testing.T) {
 	}
 }
 
+func TestNewDataCenterLookup(t *testing.T) {
+	type args struct {
+		idOrPermalink string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *DataCenter
+		field FieldName
+	}{
+		{
+			name:  "empty string",
+			args:  args{idOrPermalink: ""},
+			want:  &DataCenter{},
+			field: PermalinkField,
+		},
+		{
+			name:  "dc_ prefixed ID",
+			args:  args{idOrPermalink: "dc_HHwnaBCIwNHqv0aO"},
+			want:  &DataCenter{ID: "dc_HHwnaBCIwNHqv0aO"},
+			field: IDField,
+		},
+		{
+			name:  "loc_ prefixed ID",
+			args:  args{idOrPermalink: "loc_RuHTM4fyzucbYGCK"},
+			want:  &DataCenter{ID: "loc_RuHTM4fyzucbYGCK"},
+			field: IDField,
+		},
+		{
+			name:  "permalink",
+			args:  args{idOrPermalink: "country-city-1"},
+			want:  &DataCenter{Permalink: "country-city-1"},
+			field: PermalinkField,
+		},
+		{
+			name:  "random text",
+			args:  args{idOrPermalink: "dXUt33rNLmbatuAa"},
+			want:  &DataCenter{Permalink: "dXUt33rNLmbatuAa"},
+			field: PermalinkField,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, field := NewDataCenterLookup(tt.args.idOrPermalink)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.field, field)
+		})
+	}
+}
+
 func TestDataCenter_lookupReference(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/katapult/disk_template.go
+++ b/pkg/katapult/disk_template.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const diskTemplateIDPrefix = "dtpl_"
-
 type DiskTemplate struct {
 	ID              string               `json:"id,omitempty"`
 	Name            string               `json:"name,omitempty"`
@@ -16,6 +14,20 @@ type DiskTemplate struct {
 	Universal       bool                 `json:"universal,omitempty"`
 	LatestVersion   *DiskTemplateVersion `json:"latest_version,omitempty"`
 	OperatingSystem *OperatingSystem     `json:"operating_system,omitempty"`
+}
+
+// NewDiskTemplateLookup takes a string that is a DiskTemplate ID or Permalink,
+// returning a empty *DiskTemplate struct with either the ID or Permalink field
+// populated with the given value. This struct is suitable as input to other
+// methods which accept a *DiskTemplate as input.
+func NewDiskTemplateLookup(
+	idOrPermalink string,
+) (lr *DiskTemplate, f FieldName) {
+	if strings.HasPrefix(idOrPermalink, "dtpl_") {
+		return &DiskTemplate{ID: idOrPermalink}, IDField
+	}
+
+	return &DiskTemplate{Permalink: idOrPermalink}, PermalinkField
 }
 
 func (s *DiskTemplate) lookupReference() *DiskTemplate {
@@ -121,7 +133,7 @@ func (s *DiskTemplatesClient) Get(
 	ctx context.Context,
 	idOrPermalink string,
 ) (*DiskTemplate, *Response, error) {
-	if strings.HasPrefix(idOrPermalink, diskTemplateIDPrefix) {
+	if _, f := NewDiskTemplateLookup(idOrPermalink); f == IDField {
 		return s.GetByID(ctx, idOrPermalink)
 	}
 

--- a/pkg/katapult/disk_template_test.go
+++ b/pkg/katapult/disk_template_test.go
@@ -68,6 +68,51 @@ func TestDiskTemplate_JSONMarshaling(t *testing.T) {
 	}
 }
 
+func TestNewDiskTemplateLookup(t *testing.T) {
+	type args struct {
+		idOrPermalink string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *DiskTemplate
+		field FieldName
+	}{
+		{
+			name:  "empty string",
+			args:  args{idOrPermalink: ""},
+			want:  &DiskTemplate{},
+			field: PermalinkField,
+		},
+		{
+			name:  "dtpl_ prefixed ID",
+			args:  args{idOrPermalink: "dtpl_xnboGWaq0xROo0Sf"},
+			want:  &DiskTemplate{ID: "dtpl_xnboGWaq0xROo0Sf"},
+			field: IDField,
+		},
+		{
+			name:  "permalink",
+			args:  args{idOrPermalink: "country-city-01"},
+			want:  &DiskTemplate{Permalink: "country-city-01"},
+			field: PermalinkField,
+		},
+		{
+			name:  "random text",
+			args:  args{idOrPermalink: "dXUt33rNLmbatuAa"},
+			want:  &DiskTemplate{Permalink: "dXUt33rNLmbatuAa"},
+			field: PermalinkField,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, field := NewDiskTemplateLookup(tt.args.idOrPermalink)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.field, field)
+		})
+	}
+}
+
 func TestDiskTemplate_lookupReference(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/katapult/dns_zone.go
+++ b/pkg/katapult/dns_zone.go
@@ -7,14 +7,26 @@ import (
 	"strings"
 )
 
-const dnsZoneIDPrefix = "dnszone_"
-
 type DNSZone struct {
 	ID                 string `json:"id,omitempty"`
 	Name               string `json:"name,omitempty"`
 	TTL                int    `json:"ttl,omitempty"`
 	Verified           bool   `json:"verified,omitempty"`
 	InfrastructureZone bool   `json:"infrastructure_zone,omitempty"`
+}
+
+// NewDNSZoneLookup takes a string that is a DNSZone ID or Name, returning a
+// empty *DNSZone struct with either the ID or Name field populated with the
+// given value. This struct is suitable as input to other methods which accept a
+// *DNSZone as input.
+func NewDNSZoneLookup(
+	idOrName string,
+) (lr *DNSZone, f FieldName) {
+	if strings.HasPrefix(idOrName, "dnszone_") {
+		return &DNSZone{ID: idOrName}, IDField
+	}
+
+	return &DNSZone{Name: idOrName}, NameField
 }
 
 func (s *DNSZone) lookupReference() *DNSZone {
@@ -117,7 +129,7 @@ func (s *DNSZonesClient) Get(
 	ctx context.Context,
 	idOrName string,
 ) (*DNSZone, *Response, error) {
-	if strings.HasPrefix(idOrName, dnsZoneIDPrefix) {
+	if _, f := NewDNSZoneLookup(idOrName); f == IDField {
 		return s.GetByID(ctx, idOrName)
 	}
 

--- a/pkg/katapult/dns_zone_test.go
+++ b/pkg/katapult/dns_zone_test.go
@@ -66,6 +66,51 @@ func TestDNSZone_JSONMarshaling(t *testing.T) {
 	}
 }
 
+func TestNewDNSZoneLookup(t *testing.T) {
+	type args struct {
+		idOrName string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *DNSZone
+		field FieldName
+	}{
+		{
+			name:  "empty string",
+			args:  args{idOrName: ""},
+			want:  &DNSZone{},
+			field: NameField,
+		},
+		{
+			name:  "dnszone_ prefixed ID",
+			args:  args{idOrName: "dnszone_L9t6URxo1600lM9C"},
+			want:  &DNSZone{ID: "dnszone_L9t6URxo1600lM9C"},
+			field: IDField,
+		},
+		{
+			name:  "name",
+			args:  args{idOrName: "acme-labs.katapult.cloud"},
+			want:  &DNSZone{Name: "acme-labs.katapult.cloud"},
+			field: NameField,
+		},
+		{
+			name:  "random text",
+			args:  args{idOrName: "txgi81hUaEcPYNpF"},
+			want:  &DNSZone{Name: "txgi81hUaEcPYNpF"},
+			field: NameField,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, field := NewDNSZoneLookup(tt.args.idOrName)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.field, field)
+		})
+	}
+}
+
 func TestDNSZone_lookupReference(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/katapult/field_name.go
+++ b/pkg/katapult/field_name.go
@@ -1,0 +1,13 @@
+package katapult
+
+type FieldName int
+
+const (
+	AddressField FieldName = iota
+	FQDNField
+	IDField
+	NameField
+	ObjectIDField
+	PermalinkField
+	SubDomainField
+)

--- a/pkg/katapult/ip_address.go
+++ b/pkg/katapult/ip_address.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 )
 
-const ipAddressIDPrefix = "ip_"
-
 type IPAddress struct {
 	ID              string   `json:"id,omitempty"`
 	Address         string   `json:"address,omitempty"`
@@ -18,6 +16,20 @@ type IPAddress struct {
 	Network         *Network `json:"network,omitempty"`
 	AllocationID    string   `json:"allocation_id,omitempty"`
 	AllocationType  string   `json:"allocation_type,omitempty"`
+}
+
+// NewIPAddressLookup takes a string that is a IPAddress ID or Address,
+// returning a empty *IPAddress struct with either the ID or Address field
+// populated with the given value. This struct is suitable as input to other
+// methods which accept a *IPAddress as input.
+func NewIPAddressLookup(
+	idOrAddress string,
+) (lr *IPAddress, f FieldName) {
+	if strings.HasPrefix(idOrAddress, "ip_") {
+		return &IPAddress{ID: idOrAddress}, IDField
+	}
+
+	return &IPAddress{Address: idOrAddress}, AddressField
 }
 
 func (s *IPAddress) lookupReference() *IPAddress {
@@ -115,7 +127,7 @@ func (s *IPAddressesClient) Get(
 	ctx context.Context,
 	idOrAddress string,
 ) (*IPAddress, *Response, error) {
-	if strings.HasPrefix(idOrAddress, ipAddressIDPrefix) {
+	if _, f := NewIPAddressLookup(idOrAddress); f == IDField {
 		return s.GetByID(ctx, idOrAddress)
 	}
 

--- a/pkg/katapult/ip_address_test.go
+++ b/pkg/katapult/ip_address_test.go
@@ -93,6 +93,51 @@ func TestIPAddress_JSONMarshaling(t *testing.T) {
 	}
 }
 
+func TestNewIPAddressLookup(t *testing.T) {
+	type args struct {
+		idOrAddress string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *IPAddress
+		field FieldName
+	}{
+		{
+			name:  "empty string",
+			args:  args{idOrAddress: ""},
+			want:  &IPAddress{},
+			field: AddressField,
+		},
+		{
+			name:  "ip_ prefixed ID",
+			args:  args{idOrAddress: "ip_robwZQGtT4hnAsx4"},
+			want:  &IPAddress{ID: "ip_robwZQGtT4hnAsx4"},
+			field: IDField,
+		},
+		{
+			name:  "address",
+			args:  args{idOrAddress: "51.130.20.179"},
+			want:  &IPAddress{Address: "51.130.20.179"},
+			field: AddressField,
+		},
+		{
+			name:  "random text",
+			args:  args{idOrAddress: "oiTx8fUUh7f32GSw"},
+			want:  &IPAddress{Address: "oiTx8fUUh7f32GSw"},
+			field: AddressField,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, field := NewIPAddressLookup(tt.args.idOrAddress)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.field, field)
+		})
+	}
+}
+
 func TestIPAddress_lookupReference(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/katapult/network.go
+++ b/pkg/katapult/network.go
@@ -6,13 +6,25 @@ import (
 	"strings"
 )
 
-const networkIDPrefix = "netw_"
-
 type Network struct {
 	ID         string      `json:"id,omitempty"`
 	Name       string      `json:"name,omitempty"`
 	Permalink  string      `json:"permalink,omitempty"`
 	DataCenter *DataCenter `json:"data_center,omitempty"`
+}
+
+// NewNetworkLookup takes a string that is a Network ID or Permalink, returning
+// a empty *Network struct with either the ID or Permalink field populated with
+// the given value. This struct is suitable as input to other methods which
+// accept a *Network as input.
+func NewNetworkLookup(
+	idOrPermalink string,
+) (lr *Network, f FieldName) {
+	if strings.HasPrefix(idOrPermalink, "netw_") {
+		return &Network{ID: idOrPermalink}, IDField
+	}
+
+	return &Network{Permalink: idOrPermalink}, PermalinkField
 }
 
 func (s *Network) lookupReference() *Network {
@@ -85,7 +97,7 @@ func (s *NetworksClient) Get(
 	ctx context.Context,
 	idOrPermalink string,
 ) (*Network, *Response, error) {
-	if strings.HasPrefix(idOrPermalink, networkIDPrefix) {
+	if _, f := NewNetworkLookup(idOrPermalink); f == IDField {
 		return s.GetByID(ctx, idOrPermalink)
 	}
 

--- a/pkg/katapult/network_test.go
+++ b/pkg/katapult/network_test.go
@@ -63,6 +63,51 @@ func TestNetwork_JSONMarshaling(t *testing.T) {
 	}
 }
 
+func TestNewNetworkLookup(t *testing.T) {
+	type args struct {
+		idOrPermalink string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *Network
+		field FieldName
+	}{
+		{
+			name:  "empty string",
+			args:  args{idOrPermalink: ""},
+			want:  &Network{},
+			field: PermalinkField,
+		},
+		{
+			name:  "netw_ prefixed ID",
+			args:  args{idOrPermalink: "netw_UoGX2x12BlVK0CAo"},
+			want:  &Network{ID: "netw_UoGX2x12BlVK0CAo"},
+			field: IDField,
+		},
+		{
+			name:  "permalink",
+			args:  args{idOrPermalink: "country-city-1-public"},
+			want:  &Network{Permalink: "country-city-1-public"},
+			field: PermalinkField,
+		},
+		{
+			name:  "random text",
+			args:  args{idOrPermalink: "JRdJ017AgV4WYbkv"},
+			want:  &Network{Permalink: "JRdJ017AgV4WYbkv"},
+			field: PermalinkField,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, field := NewNetworkLookup(tt.args.idOrPermalink)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.field, field)
+		})
+	}
+}
+
 func TestNetwork_lookupReference(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/katapult/organization.go
+++ b/pkg/katapult/organization.go
@@ -9,8 +9,6 @@ import (
 	"github.com/augurysys/timestamp"
 )
 
-const organizationIDPrefix = "org_"
-
 type Organization struct {
 	ID                   string               `json:"id,omitempty"`
 	Name                 string               `json:"name,omitempty"`
@@ -30,6 +28,20 @@ type Organization struct {
 	Currency             *Currency            `json:"currency,omitempty"`
 	Country              *Country             `json:"country,omitempty"`
 	CountryState         *CountryState        `json:"country_state,omitempty"`
+}
+
+// NewOrganizationLookup takes a string that is a Organization ID or SubDomain,
+// returning a empty *Organization struct with either the ID or SubDomain field
+// populated with the given value. This struct is suitable as input to other
+// methods which accept a *Organization as input.
+func NewOrganizationLookup(
+	idOrSubDomain string,
+) (lr *Organization, f FieldName) {
+	if strings.HasPrefix(idOrSubDomain, "org_") {
+		return &Organization{ID: idOrSubDomain}, IDField
+	}
+
+	return &Organization{SubDomain: idOrSubDomain}, SubDomainField
 }
 
 func (s *Organization) lookupReference() *Organization {
@@ -101,7 +113,7 @@ func (s *OrganizationsClient) Get(
 	ctx context.Context,
 	idOrSubDomain string,
 ) (*Organization, *Response, error) {
-	if strings.HasPrefix(idOrSubDomain, organizationIDPrefix) {
+	if _, f := NewOrganizationLookup(idOrSubDomain); f == IDField {
 		return s.GetByID(ctx, idOrSubDomain)
 	}
 

--- a/pkg/katapult/organization_test.go
+++ b/pkg/katapult/organization_test.go
@@ -73,6 +73,51 @@ func TestOrganization_JSONMarshaling(t *testing.T) {
 	}
 }
 
+func TestNewOrganizationLookup(t *testing.T) {
+	type args struct {
+		idOrSubDomain string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *Organization
+		field FieldName
+	}{
+		{
+			name:  "empty string",
+			args:  args{idOrSubDomain: ""},
+			want:  &Organization{},
+			field: SubDomainField,
+		},
+		{
+			name:  "org_ prefixed ID",
+			args:  args{idOrSubDomain: "org_4LmWzxTJ5PRn8BZx"},
+			want:  &Organization{ID: "org_4LmWzxTJ5PRn8BZx"},
+			field: IDField,
+		},
+		{
+			name:  "subdomain",
+			args:  args{idOrSubDomain: "acme-labs"},
+			want:  &Organization{SubDomain: "acme-labs"},
+			field: SubDomainField,
+		},
+		{
+			name:  "random text",
+			args:  args{idOrSubDomain: "yz0ka92Cq92FM39l"},
+			want:  &Organization{SubDomain: "yz0ka92Cq92FM39l"},
+			field: SubDomainField,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, field := NewOrganizationLookup(tt.args.idOrSubDomain)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.field, field)
+		})
+	}
+}
+
 func TestOrganization_lookupReference(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/katapult/trash_object.go
+++ b/pkg/katapult/trash_object.go
@@ -8,13 +8,25 @@ import (
 	"github.com/augurysys/timestamp"
 )
 
-const trashObjectIDPrefix = "trsh_"
-
 type TrashObject struct {
 	ID         string               `json:"id,omitempty"`
 	KeepUntil  *timestamp.Timestamp `json:"keep_until,omitempty"`
 	ObjectID   string               `json:"object_id,omitempty"`
 	ObjectType string               `json:"object_type,omitempty"`
+}
+
+// NewTrashObjectLookup takes a string that is a TrashObject ID or ObjectID
+// returning, a empty *TrashObject struct with either the ID or ObjectID field
+// populated with the given value. This struct is suitable as input to other
+// methods which accept a *TrashObject as input.
+func NewTrashObjectLookup(
+	idOrObjectID string,
+) (lr *TrashObject, f FieldName) {
+	if strings.HasPrefix(idOrObjectID, "trsh_") {
+		return &TrashObject{ID: idOrObjectID}, IDField
+	}
+
+	return &TrashObject{ObjectID: idOrObjectID}, ObjectIDField
 }
 
 func (s *TrashObject) lookupReference() *TrashObject {
@@ -85,7 +97,7 @@ func (s *TrashObjectsClient) Get(
 	ctx context.Context,
 	idOrObjectID string,
 ) (*TrashObject, *Response, error) {
-	if strings.HasPrefix(idOrObjectID, trashObjectIDPrefix) {
+	if _, f := NewTrashObjectLookup(idOrObjectID); f == IDField {
 		return s.GetByID(ctx, idOrObjectID)
 	}
 

--- a/pkg/katapult/trash_object_test.go
+++ b/pkg/katapult/trash_object_test.go
@@ -58,6 +58,51 @@ func TestTrashObject_JSONMarshaling(t *testing.T) {
 	}
 }
 
+func TestNewTrashObjectLookup(t *testing.T) {
+	type args struct {
+		idOrObjectID string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *TrashObject
+		field FieldName
+	}{
+		{
+			name:  "empty string",
+			args:  args{idOrObjectID: ""},
+			want:  &TrashObject{},
+			field: ObjectIDField,
+		},
+		{
+			name:  "trsh_ prefixed ID",
+			args:  args{idOrObjectID: "trsh_vAGgmacZGf2ucIcx"},
+			want:  &TrashObject{ID: "trsh_vAGgmacZGf2ucIcx"},
+			field: IDField,
+		},
+		{
+			name:  "object ID",
+			args:  args{idOrObjectID: "vm_2yiadNK5xxJiclVq"},
+			want:  &TrashObject{ObjectID: "vm_2yiadNK5xxJiclVq"},
+			field: ObjectIDField,
+		},
+		{
+			name:  "random text",
+			args:  args{idOrObjectID: "JKeIKf2ILMw4OEaw"},
+			want:  &TrashObject{ObjectID: "JKeIKf2ILMw4OEaw"},
+			field: ObjectIDField,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, field := NewTrashObjectLookup(tt.args.idOrObjectID)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.field, field)
+		})
+	}
+}
+
 func TestTrashObject_lookupReference(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/katapult/virtual_machine.go
+++ b/pkg/katapult/virtual_machine.go
@@ -8,8 +8,6 @@ import (
 	"github.com/augurysys/timestamp"
 )
 
-const virtualMachineIDPrefix = "vm_"
-
 type VirtualMachine struct {
 	ID                  string                 `json:"id,omitempty"`
 	Name                string                 `json:"name,omitempty"`
@@ -27,6 +25,20 @@ type VirtualMachine struct {
 	Tags                []*Tag                 `json:"tags,omitempty"`
 	TagNames            []string               `json:"tag_names,omitempty"`
 	IPAddresses         []*IPAddress           `json:"ip_addresses,omitempty"`
+}
+
+// NewVirtualMachineLookup takes a string that is a VirtualMachine ID or FQDN,
+// returning a empty *VirtualMachine struct with either the ID or FQDN field
+// populated with the given value. This struct is suitable as input to other
+// methods which accept a *VirtualMachine as input.
+func NewVirtualMachineLookup(
+	idOrFQDN string,
+) (lr *VirtualMachine, f FieldName) {
+	if strings.HasPrefix(idOrFQDN, "vm_") {
+		return &VirtualMachine{ID: idOrFQDN}, IDField
+	}
+
+	return &VirtualMachine{FQDN: idOrFQDN}, FQDNField
 }
 
 func (s *VirtualMachine) lookupReference() *VirtualMachine {
@@ -138,7 +150,7 @@ func (s *VirtualMachinesClient) Get(
 	ctx context.Context,
 	idOrFQDN string,
 ) (*VirtualMachine, *Response, error) {
-	if strings.HasPrefix(idOrFQDN, virtualMachineIDPrefix) {
+	if _, f := NewVirtualMachineLookup(idOrFQDN); f == IDField {
 		return s.GetByID(ctx, idOrFQDN)
 	}
 

--- a/pkg/katapult/virtual_machine_package.go
+++ b/pkg/katapult/virtual_machine_package.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 )
 
-const virtualMachinePackageIDPrefix = "vmpkg_"
-
 type VirtualMachinePackage struct {
 	ID            string      `json:"id,omitempty"`
 	Name          string      `json:"name,omitempty"`
@@ -19,6 +17,21 @@ type VirtualMachinePackage struct {
 	StorageInGB   int         `json:"storage_in_gb,omitempty"`
 	Privacy       string      `json:"privacy,omitempty"`
 	Icon          *Attachment `json:"icon,omitempty"`
+}
+
+// NewVirtualMachinePackageLookup takes a string that is a VirtualMachinePackage
+// ID or Permalink returning, a empty *VirtualMachinePackage struct with either
+// the ID or Permalink field populated with the given value. This struct is
+// suitable as input to other methods which accept a *VirtualMachinePackage as
+// input.
+func NewVirtualMachinePackageLookup(
+	idOrPermalink string,
+) (lr *VirtualMachinePackage, f FieldName) {
+	if strings.HasPrefix(idOrPermalink, "vmpkg_") {
+		return &VirtualMachinePackage{ID: idOrPermalink}, IDField
+	}
+
+	return &VirtualMachinePackage{Permalink: idOrPermalink}, PermalinkField
 }
 
 func (s *VirtualMachinePackage) lookupReference() *VirtualMachinePackage {
@@ -73,7 +86,7 @@ func (s *VirtualMachinePackagesClient) Get(
 	ctx context.Context,
 	idOrPermalink string,
 ) (*VirtualMachinePackage, *Response, error) {
-	if strings.HasPrefix(idOrPermalink, virtualMachinePackageIDPrefix) {
+	if _, f := NewVirtualMachinePackageLookup(idOrPermalink); f == IDField {
 		return s.GetByID(ctx, idOrPermalink)
 	}
 

--- a/pkg/katapult/virtual_machine_package_test.go
+++ b/pkg/katapult/virtual_machine_package_test.go
@@ -53,6 +53,51 @@ func TestVirtualMachinePackage_JSONMarshaling(t *testing.T) {
 	}
 }
 
+func TestNewVirtualMachinePackageLookup(t *testing.T) {
+	type args struct {
+		idOrPermalink string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *VirtualMachinePackage
+		field FieldName
+	}{
+		{
+			name:  "empty string",
+			args:  args{idOrPermalink: ""},
+			want:  &VirtualMachinePackage{},
+			field: PermalinkField,
+		},
+		{
+			name:  "vmpkg_ prefixed ID",
+			args:  args{idOrPermalink: "vmpkg_bVCqY58SxSwheKV6"},
+			want:  &VirtualMachinePackage{ID: "vmpkg_bVCqY58SxSwheKV6"},
+			field: IDField,
+		},
+		{
+			name:  "permalink",
+			args:  args{idOrPermalink: "rock-3"},
+			want:  &VirtualMachinePackage{Permalink: "rock-3"},
+			field: PermalinkField,
+		},
+		{
+			name:  "random text",
+			args:  args{idOrPermalink: "Z0jCwfGCIzli3Vk5"},
+			want:  &VirtualMachinePackage{Permalink: "Z0jCwfGCIzli3Vk5"},
+			field: PermalinkField,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, field := NewVirtualMachinePackageLookup(tt.args.idOrPermalink)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.field, field)
+		})
+	}
+}
+
 func TestVirtualMachinePackage_lookupReference(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/katapult/virtual_machine_test.go
+++ b/pkg/katapult/virtual_machine_test.go
@@ -95,6 +95,51 @@ func TestVirtualMachine_JSONMarshaling(t *testing.T) {
 	}
 }
 
+func TestNewVirtualMachineLookup(t *testing.T) {
+	type args struct {
+		idOrFQDN string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *VirtualMachine
+		field FieldName
+	}{
+		{
+			name:  "empty string",
+			args:  args{idOrFQDN: ""},
+			want:  &VirtualMachine{},
+			field: FQDNField,
+		},
+		{
+			name:  "vm_ prefixed ID",
+			args:  args{idOrFQDN: "vm_rq1Zdv6aC66bvsU7"},
+			want:  &VirtualMachine{ID: "vm_rq1Zdv6aC66bvsU7"},
+			field: IDField,
+		},
+		{
+			name:  "fqdn",
+			args:  args{idOrFQDN: "noisy-pink-banana"},
+			want:  &VirtualMachine{FQDN: "noisy-pink-banana"},
+			field: FQDNField,
+		},
+		{
+			name:  "random text",
+			args:  args{idOrFQDN: "4lgGRmCPW7XhizQj"},
+			want:  &VirtualMachine{FQDN: "4lgGRmCPW7XhizQj"},
+			field: FQDNField,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, field := NewVirtualMachineLookup(tt.args.idOrFQDN)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.field, field)
+		})
+	}
+}
+
 func TestVirtualMachine_lookupReference(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/katapult/zone.go
+++ b/pkg/katapult/zone.go
@@ -1,10 +1,26 @@
 package katapult
 
+import "strings"
+
 type Zone struct {
 	ID         string      `json:"id,omitempty"`
 	Name       string      `json:"name,omitempty"`
 	Permalink  string      `json:"permalink,omitempty"`
 	DataCenter *DataCenter `json:"data_center,omitempty"`
+}
+
+// NewZoneLookup takes a string that is a Zone ID or Permalink, returning a
+// empty *Zone struct with either the ID or Permalink field populated with the
+// given value. This struct is suitable as input to other methods which accept a
+// *Zone as input.
+func NewZoneLookup(
+	idOrPermalink string,
+) (lr *Zone, f FieldName) {
+	if strings.HasPrefix(idOrPermalink, "zone_") {
+		return &Zone{ID: idOrPermalink}, IDField
+	}
+
+	return &Zone{Permalink: idOrPermalink}, PermalinkField
 }
 
 func (s *Zone) lookupReference() *Zone {

--- a/pkg/katapult/zone_test.go
+++ b/pkg/katapult/zone_test.go
@@ -46,6 +46,51 @@ func TestZone_JSONMarshaling(t *testing.T) {
 	}
 }
 
+func TestNewZoneLookup(t *testing.T) {
+	type args struct {
+		idOrPermalink string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *Zone
+		field FieldName
+	}{
+		{
+			name:  "empty string",
+			args:  args{idOrPermalink: ""},
+			want:  &Zone{},
+			field: PermalinkField,
+		},
+		{
+			name:  "zone_ prefixed ID",
+			args:  args{idOrPermalink: "zone_NeK95mFtiSXfUtW2"},
+			want:  &Zone{ID: "zone_NeK95mFtiSXfUtW2"},
+			field: IDField,
+		},
+		{
+			name:  "permalink",
+			args:  args{idOrPermalink: "city-zone-1"},
+			want:  &Zone{Permalink: "city-zone-1"},
+			field: PermalinkField,
+		},
+		{
+			name:  "random text",
+			args:  args{idOrPermalink: "1UKzPq0izsQsNCsd"},
+			want:  &Zone{Permalink: "1UKzPq0izsQsNCsd"},
+			field: PermalinkField,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, field := NewZoneLookup(tt.args.idOrPermalink)
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.field, field)
+		})
+	}
+}
+
 func TestZone_lookupReference(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
For resource types which can be looked up / queried based on multiple fields,
these new functions allows creating a shallow struct which just contains the
relevant lookup field.

Most methods which accept resources as input, like the
`Create(context.Context, *Organization, *IPAddressCreateArguments)` function on
the `IPAddressesClient`, only uses the `*Organization` to figure out which
organization to create the IP within. This means it does not need to be a
complete `*Organization` with all fields populated, but instead it can be a
shallow struct containing only a `ID` or `SubDomain` value.

The `NewOrganizationLookup()` function accepts a string that can either be a
organization ID (formatted as `org_<random>`), or a organization sub-domain
(formatted as a DNS Label). Based on the format of the given string, the
returned \*`Organization` will have the given string populated as either the
`ID` or `SubDomain` field.