### PR TITLE
feat(virtual_machine_groups): add List endpoint

### DIFF
--- a/pkg/katapult/client.go
+++ b/pkg/katapult/client.go
@@ -39,6 +39,7 @@ type Client struct {
 	Tasks                           *TasksClient
 	TrashObjects                    *TrashObjectsClient
 	VirtualMachineBuilds            *VirtualMachineBuildsClient
+	VirtualMachineGroups            *VirtualMachineGroupsClient
 	VirtualMachineNetworkInterfaces *VirtualMachineNetworkInterfacesClient
 	VirtualMachinePackages          *VirtualMachinePackagesClient
 	VirtualMachines                 *VirtualMachinesClient
@@ -66,6 +67,7 @@ func NewClient(config *Config) (*Client, error) {
 		Tasks:                           newTasksClient(ac),
 		TrashObjects:                    newTrashObjectsClient(ac),
 		VirtualMachineBuilds:            newVirtualMachineBuildsClient(ac),
+		VirtualMachineGroups:            newVirtualMachineGroupsClient(ac),
 		VirtualMachineNetworkInterfaces: newVirtualMachineNetworkInterfacesClient(ac),
 		VirtualMachinePackages:          newVirtualMachinePackagesClient(ac),
 		VirtualMachines:                 newVirtualMachinesClient(ac),

--- a/pkg/katapult/fixtures/organization_not_activated_error.json
+++ b/pkg/katapult/fixtures/organization_not_activated_error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "organization_not_activated",
+    "description": "An organization was found from the arguments provided but it wasn't activated yet",
+    "detail": {}
+  }
+}

--- a/pkg/katapult/fixtures/virtual_machine_groups_list.json
+++ b/pkg/katapult/fixtures/virtual_machine_groups_list.json
@@ -1,0 +1,14 @@
+{
+  "virtual_machine_groups": [
+    {
+      "id": "vmgrp_gsEUFPp3ybVQm5QQ",
+      "name": "vm group 1",
+      "segregate": true
+    },
+    {
+      "id": "vmgrp_bcfdEFn2viWCm5ve",
+      "name": "vm group 2",
+      "segregate": false
+    }
+  ]
+}

--- a/pkg/katapult/organization_test.go
+++ b/pkg/katapult/organization_test.go
@@ -31,6 +31,16 @@ var (
 			"criteria provided in the arguments",
 		Detail: json.RawMessage(`{}`),
 	}
+
+	fixtureOrganizationNotActivatedErr = "organization_not_activated: " +
+		"An organization was found from the arguments provided but it wasn't " +
+		"activated yet"
+	fixtureOrganizationNotActivatedResponseError = &ResponseError{
+		Code: "organization_not_activated",
+		Description: "An organization was found from the arguments provided " +
+			"but it wasn't activated yet",
+		Detail: json.RawMessage(`{}`),
+	}
 )
 
 func TestOrganization_JSONMarshaling(t *testing.T) {
@@ -511,6 +521,17 @@ func TestOrganizationsClient_Get(t *testing.T) {
 			respBody:   fixture("organization_suspended_error"),
 		},
 		{
+			name: "not activated organization",
+			args: args{
+				ctx:           context.Background(),
+				idOrSubDomain: "org_O648YDMEYeLmqdmn",
+			},
+			errStr:     fixtureOrganizationNotActivatedErr,
+			errResp:    fixtureOrganizationNotActivatedResponseError,
+			respStatus: http.StatusForbidden,
+			respBody:   fixture("organization_not_activated_error"),
+		},
+		{
 			name: "nil context",
 			args: args{
 				ctx:           nil,
@@ -621,6 +642,17 @@ func TestOrganizationsClient_GetByID(t *testing.T) {
 			respBody:   fixture("organization_suspended_error"),
 		},
 		{
+			name: "not activated organization",
+			args: args{
+				ctx: context.Background(),
+				id:  "org_O648YDMEYeLmqdmn",
+			},
+			errStr:     fixtureOrganizationNotActivatedErr,
+			errResp:    fixtureOrganizationNotActivatedResponseError,
+			respStatus: http.StatusForbidden,
+			respBody:   fixture("organization_not_activated_error"),
+		},
+		{
 			name: "nil context",
 			args: args{
 				ctx: nil,
@@ -717,6 +749,17 @@ func TestOrganizationsClient_GetBySubDomain(t *testing.T) {
 			errResp:    fixtureOrganizationSuspendedResponseError,
 			respStatus: http.StatusForbidden,
 			respBody:   fixture("organization_suspended_error"),
+		},
+		{
+			name: "not activated organization",
+			args: args{
+				ctx:       context.Background(),
+				subDomain: "acme",
+			},
+			errStr:     fixtureOrganizationNotActivatedErr,
+			errResp:    fixtureOrganizationNotActivatedResponseError,
+			respStatus: http.StatusForbidden,
+			respBody:   fixture("organization_not_activated_error"),
 		},
 		{
 			name: "nil context",
@@ -892,6 +935,21 @@ func TestOrganizationsClient_CreateManaged(t *testing.T) {
 			errResp:    fixtureOrganizationSuspendedResponseError,
 			respStatus: http.StatusForbidden,
 			respBody:   fixture("organization_suspended_error"),
+		},
+		{
+			name: "not activated organization",
+			args: args{
+				ctx:    context.Background(),
+				parent: &Organization{ID: "org_O648YDMEYeLmqdmn"},
+				args: &OrganizationManagedArguments{
+					Name:      "NERV Corp.",
+					SubDomain: "nerv",
+				},
+			},
+			errStr:     fixtureOrganizationNotActivatedErr,
+			errResp:    fixtureOrganizationNotActivatedResponseError,
+			respStatus: http.StatusForbidden,
+			respBody:   fixture("organization_not_activated_error"),
 		},
 		{
 			name: "validation error for new org details",

--- a/pkg/katapult/virtual_machine.go
+++ b/pkg/katapult/virtual_machine.go
@@ -83,13 +83,6 @@ const (
 	VirtualMachineOrphaned     VirtualMachineState = "orphaned"
 )
 
-type VirtualMachineGroup struct {
-	ID        string               `json:"id,omitempty"`
-	Name      string               `json:"name,omitempty"`
-	Segregate bool                 `json:"segregate,omitempty"`
-	CreatedAt *timestamp.Timestamp `json:"created_at,omitempty"`
-}
-
 type VirtualMachineUpdateArguments struct {
 	Name        string    `json:"name,omitempty"`
 	Hostname    string    `json:"hostname,omitempty"`

--- a/pkg/katapult/virtual_machine_group.go
+++ b/pkg/katapult/virtual_machine_group.go
@@ -1,0 +1,66 @@
+package katapult
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/augurysys/timestamp"
+)
+
+type VirtualMachineGroup struct {
+	ID        string               `json:"id,omitempty"`
+	Name      string               `json:"name,omitempty"`
+	Segregate bool                 `json:"segregate,omitempty"`
+	CreatedAt *timestamp.Timestamp `json:"created_at,omitempty"`
+}
+
+type VirtualMachineGroupsClient struct {
+	client   *apiClient
+	basePath *url.URL
+}
+
+type virtualMachineGroupsResponseBody struct {
+	VirtualMachineGroups []*VirtualMachineGroup `json:"virtual_machine_groups,omitempty"`
+}
+
+func newVirtualMachineGroupsClient(
+	c *apiClient,
+) *VirtualMachineGroupsClient {
+	return &VirtualMachineGroupsClient{
+		client:   c,
+		basePath: &url.URL{Path: "/core/v1/"},
+	}
+}
+
+func (s *VirtualMachineGroupsClient) List(
+	ctx context.Context,
+	org *Organization,
+) ([]*VirtualMachineGroup, *Response, error) {
+	qs := queryValues(org)
+	u := &url.URL{
+		Path:     "organizations/_/virtual_machine_groups",
+		RawQuery: qs.Encode(),
+	}
+
+	body, resp, err := s.doRequest(ctx, "GET", u, nil)
+
+	return body.VirtualMachineGroups, resp, err
+}
+
+func (s *VirtualMachineGroupsClient) doRequest(
+	ctx context.Context,
+	method string,
+	u *url.URL,
+	body interface{},
+) (*virtualMachineGroupsResponseBody, *Response, error) {
+	u = s.basePath.ResolveReference(u)
+	respBody := &virtualMachineGroupsResponseBody{}
+	resp := newResponse(nil)
+
+	req, err := s.client.NewRequestWithContext(ctx, method, u, body)
+	if err == nil {
+		resp, err = s.client.Do(req, respBody)
+	}
+
+	return respBody, resp, err
+}

--- a/pkg/katapult/virtual_machine_group_test.go
+++ b/pkg/katapult/virtual_machine_group_test.go
@@ -1,0 +1,215 @@
+package katapult
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVirtualMachineGroup_JSONMarshaling(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  *VirtualMachineGroup
+	}{
+		{
+			name: "empty",
+			obj:  &VirtualMachineGroup{},
+		},
+		{
+			name: "full",
+			obj: &VirtualMachineGroup{
+				ID:        "id",
+				Name:      "name",
+				Segregate: true,
+				CreatedAt: timestampPtr(934834834),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testJSONMarshaling(t, tt.obj)
+		})
+	}
+}
+
+func TestVirtualMachineGroupsClient_List(t *testing.T) {
+	// Correlates to fixtures/virtual_machine_groups_list*.json
+	virtualMachineGroupList := []*VirtualMachineGroup{
+		{
+			ID:        "vmgrp_gsEUFPp3ybVQm5QQ",
+			Name:      "vm group 1",
+			Segregate: true,
+		},
+		{
+			ID:        "vmgrp_bcfdEFn2viWCm5ve",
+			Name:      "vm group 2",
+			Segregate: false,
+		},
+	}
+
+	type args struct {
+		ctx context.Context
+		org *Organization
+	}
+	tests := []struct {
+		name       string
+		args       args
+		want       []*VirtualMachineGroup
+		wantQuery  *url.Values
+		errStr     string
+		errResp    *ResponseError
+		respStatus int
+		respBody   []byte
+	}{
+		{
+			name: "by organization ID",
+			args: args{
+				ctx: context.Background(),
+				org: &Organization{ID: "org_O648YDMEYeLmqdmn"},
+			},
+			want: virtualMachineGroupList,
+			wantQuery: &url.Values{
+				"organization[id]": []string{"org_O648YDMEYeLmqdmn"},
+			},
+			respStatus: http.StatusOK,
+			respBody:   fixture("virtual_machine_groups_list"),
+		},
+		{
+			name: "by organization SubDomain",
+			args: args{
+				ctx: context.Background(),
+				org: &Organization{SubDomain: "acme"},
+			},
+			want: virtualMachineGroupList,
+			wantQuery: &url.Values{
+				"organization[sub_domain]": []string{"acme"},
+			},
+			respStatus: http.StatusOK,
+			respBody:   fixture("virtual_machine_groups_list"),
+		},
+		{
+			name: "invalid API token response",
+			args: args{
+				ctx: context.Background(),
+				org: &Organization{ID: "org_O648YDMEYeLmqdmn"},
+			},
+			errStr:     fixtureInvalidAPITokenErr,
+			errResp:    fixtureInvalidAPITokenResponseError,
+			respStatus: http.StatusForbidden,
+			respBody:   fixture("invalid_api_token_error"),
+		},
+		{
+			name: "non-existent organization",
+			args: args{
+				ctx: context.Background(),
+				org: &Organization{ID: "org_O648YDMEYeLmqdmn"},
+			},
+			errStr:     fixtureOrganizationNotFoundErr,
+			errResp:    fixtureOrganizationNotFoundResponseError,
+			respStatus: http.StatusNotFound,
+			respBody:   fixture("organization_not_found_error"),
+		},
+		{
+			name: "nil organization",
+			args: args{
+				ctx: context.Background(),
+				org: nil,
+			},
+			errStr:     fixtureOrganizationNotFoundErr,
+			errResp:    fixtureOrganizationNotFoundResponseError,
+			respStatus: http.StatusNotFound,
+			respBody:   fixture("organization_not_found_error"),
+		},
+		{
+			name: "not activated organization",
+			args: args{
+				ctx: context.Background(),
+				org: &Organization{ID: "org_O648YDMEYeLmqdmn"},
+			},
+			errStr:     fixtureOrganizationNotActivatedErr,
+			errResp:    fixtureOrganizationNotActivatedResponseError,
+			respStatus: http.StatusForbidden,
+			respBody:   fixture("organization_not_activated_error"),
+		},
+		{
+			name: "suspended organization",
+			args: args{
+				ctx: context.Background(),
+				org: &Organization{ID: "org_O648YDMEYeLmqdmn"},
+			},
+			errStr:     fixtureOrganizationSuspendedErr,
+			errResp:    fixtureOrganizationSuspendedResponseError,
+			respStatus: http.StatusForbidden,
+			respBody:   fixture("organization_suspended_error"),
+		},
+		{
+			name: "permission denied",
+			args: args{
+				ctx: context.Background(),
+				org: &Organization{ID: "org_O648YDMEYeLmqdmn"},
+			},
+			errStr:     fixturePermissionDeniedErr,
+			errResp:    fixturePermissionDeniedResponseError,
+			respStatus: http.StatusForbidden,
+			respBody:   fixture("permission_denied_error"),
+		},
+		{
+			name: "nil context",
+			args: args{
+				ctx: nil,
+				org: &Organization{ID: "org_O648YDMEYeLmqdmn"},
+			},
+			errStr: "net/http: nil Context",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, mux, _, teardown := prepareTestClient()
+			defer teardown()
+
+			mux.HandleFunc(
+				"/core/v1/organizations/_/virtual_machine_groups",
+				func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, "GET", r.Method)
+					assertEmptyFieldSpec(t, r)
+					assertAuthorization(t, r)
+
+					if tt.wantQuery != nil {
+						assert.Equal(t, *tt.wantQuery, r.URL.Query())
+					} else {
+						qs := queryValues(tt.args.org)
+						assert.Equal(t, *qs, r.URL.Query())
+					}
+
+					w.WriteHeader(tt.respStatus)
+					_, _ = w.Write(tt.respBody)
+				},
+			)
+
+			got, resp, err := c.VirtualMachineGroups.List(
+				tt.args.ctx, tt.args.org,
+			)
+
+			if tt.respStatus != 0 {
+				assert.Equal(t, tt.respStatus, resp.StatusCode)
+			}
+
+			if tt.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.errStr)
+			}
+
+			if tt.want != nil {
+				assert.Equal(t, tt.want, got)
+			}
+
+			if tt.errResp != nil {
+				assert.Equal(t, tt.errResp, resp.Error)
+			}
+		})
+	}
+}

--- a/pkg/katapult/virtual_machine_test.go
+++ b/pkg/katapult/virtual_machine_test.go
@@ -273,32 +273,6 @@ func TestVirtualMachineStates(t *testing.T) {
 	}
 }
 
-func TestVirtualMachineGroup_JSONMarshaling(t *testing.T) {
-	tests := []struct {
-		name string
-		obj  *VirtualMachineGroup
-	}{
-		{
-			name: "empty",
-			obj:  &VirtualMachineGroup{},
-		},
-		{
-			name: "full",
-			obj: &VirtualMachineGroup{
-				ID:        "id",
-				Name:      "name",
-				Segregate: true,
-				CreatedAt: timestampPtr(934834834),
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			testJSONMarshaling(t, tt.obj)
-		})
-	}
-}
-
 func TestVirtualMachineUpdateArguments_JSONMarshaling(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Adds the [List virtual machine groups](https://developers.katapult.io/api/docs/latest/routes/organizations/:organization/virtual_machine_groups/get/) endpoint to the Katapult client.