### PR TITLE
fix(load_balancer): disable https_redirect

### DIFF
--- a/core/load_balancer.go
+++ b/core/load_balancer.go
@@ -43,7 +43,7 @@ type LoadBalancerCreateArguments struct {
 	Name          string       `json:"name,omitempty"`
 	ResourceType  ResourceType `json:"resource_type,omitempty"`
 	ResourceIDs   *[]string    `json:"resource_ids,omitempty"`
-	HTTPSRedirect bool         `json:"https_redirect,omitempty"`
+	HTTPSRedirect *bool        `json:"https_redirect,omitempty"`
 }
 
 func (
@@ -63,7 +63,7 @@ type LoadBalancerUpdateArguments struct {
 	Name          string       `json:"name,omitempty"`
 	ResourceType  ResourceType `json:"resource_type,omitempty"`
 	ResourceIDs   *[]string    `json:"resource_ids,omitempty"`
-	HTTPSRedirect bool         `json:"https_redirect,omitempty"`
+	HTTPSRedirect *bool        `json:"https_redirect,omitempty"`
 }
 
 type loadBalancerCreateRequest struct {

--- a/core/load_balancer_test.go
+++ b/core/load_balancer_test.go
@@ -184,7 +184,13 @@ func TestLoadBalancerCreateArguments_JSONMarshaling(t *testing.T) {
 				Name:          "helper",
 				ResourceType:  TagsResourceType,
 				ResourceIDs:   &[]string{"id1", "id2"},
-				HTTPSRedirect: true,
+				HTTPSRedirect: truePtr,
+			},
+		},
+		{
+			name: "false HTTPSRedirect",
+			obj: &LoadBalancerCreateArguments{
+				HTTPSRedirect: falsePtr,
 			},
 		},
 		{
@@ -304,12 +310,18 @@ func TestLoadBalancerUpdateArguments_JSONMarshaling(t *testing.T) {
 				Name:          "helper",
 				ResourceType:  TagsResourceType,
 				ResourceIDs:   &[]string{"id1", "id2"},
-				HTTPSRedirect: true,
+				HTTPSRedirect: truePtr,
 			},
 		},
 		{
 			name: "empty ResourceIDs",
 			obj:  &LoadBalancerUpdateArguments{ResourceIDs: &[]string{}},
+		},
+		{
+			name: "false HTTPSRedirect",
+			obj: &LoadBalancerUpdateArguments{
+				HTTPSRedirect: falsePtr,
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/core/testdata/TestLoadBalancerCreateArguments_JSONMarshaling/false_HTTPSRedirect.golden
+++ b/core/testdata/TestLoadBalancerCreateArguments_JSONMarshaling/false_HTTPSRedirect.golden
@@ -1,0 +1,1 @@
+{"https_redirect":false}

--- a/core/testdata/TestLoadBalancerUpdateArguments_JSONMarshaling/false_HTTPSRedirect.golden
+++ b/core/testdata/TestLoadBalancerUpdateArguments_JSONMarshaling/false_HTTPSRedirect.golden
@@ -1,0 +1,1 @@
+{"https_redirect":false}


### PR DESCRIPTION
Trying to update load balancers to set the HTTPS Redirect property to false was
not possible, as a false value would cause the field to not be included in the
marshaled JSON payload, which the API interprets as "no change".

Hence the field type needs to be `*bool` so we can distinguish between `true`,
`false`, and nil/missing.