### PR TITLE
fix(load_balancer): enable removing all certs from a rule

### DIFF
--- a/core/load_balancer_rule.go
+++ b/core/load_balancer_rule.go
@@ -65,7 +65,7 @@ type LoadBalancerRuleArguments struct {
 	ListenPort      int                       `json:"listen_port,omitempty"`
 	Protocol        Protocol                  `json:"protocol,omitempty"`
 	ProxyProtocol   *bool                     `json:"proxy_protocol,omitempty"`
-	Certificates    []CertificateRef          `json:"certificates,omitempty"`
+	Certificates    *[]CertificateRef         `json:"certificates,omitempty"`
 	CheckEnabled    *bool                     `json:"check_enabled,omitempty"`
 	CheckFall       int                       `json:"check_fall,omitempty"`
 	CheckInterval   int                       `json:"check_interval,omitempty"`

--- a/core/load_balancer_rule_test.go
+++ b/core/load_balancer_rule_test.go
@@ -99,7 +99,7 @@ func TestLoadBalancerRuleArguments_JSONMarshalling(t *testing.T) {
 				ListenPort:      1337,
 				Protocol:        HTTPProtocol,
 				ProxyProtocol:   boolPtr(false),
-				Certificates: []CertificateRef{
+				Certificates: &[]CertificateRef{
 					{
 						ID: "another abitrary string",
 					},
@@ -111,6 +111,12 @@ func TestLoadBalancerRuleArguments_JSONMarshalling(t *testing.T) {
 				CheckProtocol: HTTPProtocol,
 				CheckRise:     12,
 				CheckTimeout:  3,
+			},
+		},
+		{
+			name: "remove all certificates",
+			obj: &LoadBalancerRuleArguments{
+				Certificates: &[]CertificateRef{},
 			},
 		},
 	}

--- a/core/testdata/TestLoadBalancerRuleArguments_JSONMarshalling/remove_all_certificates.golden
+++ b/core/testdata/TestLoadBalancerRuleArguments_JSONMarshalling/remove_all_certificates.golden
@@ -1,0 +1,1 @@
+{"certificates":[]}


### PR DESCRIPTION
Previously when setting the Certificates field to a empty slice, the field would
not be sent. This prevented making a request to remove all certificates assigned
to a rule. Hence we need to make the Certificates field a slice pointer, so we
can differentiate between not provided (no change), and empty list (remove all).