### PR TITLE
fix(codegen): fix issue caused by a recent change to Katapult's API Schema

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-//go:generate go run github.com/krystal/go-katapult/tools/codegen -t errors -p katapult -o . -i Rapid\/.* -n core/v1
+//go:generate go run github.com/krystal/go-katapult/tools/codegen -t errors -p katapult -o . -i (Apia|Rapid)\/.* -n core/v1
 
 var (
 	// Err is the top-most parent of any error returned by katapult.

--- a/tools/codegen/gen/errors.go
+++ b/tools/codegen/gen/errors.go
@@ -319,15 +319,15 @@ func (g *Generator) structField(
 	}
 
 	switch f.Type {
-	case "Rapid/Scalars/Boolean":
+	case "Apia/Scalars/Boolean", "Rapid/Scalars/Boolean":
 		return jen.Id(name).Add(base.Bool().Add(tag)), nil
-	case "Rapid/Scalars/Decimal":
+	case "Apia/Scalars/Decimal", "Rapid/Scalars/Decimal":
 		return jen.Id(name).Add(base.Float64().Add(tag)), nil
-	case "Rapid/Scalars/Integer":
+	case "Apia/Scalars/Integer", "Rapid/Scalars/Integer":
 		return jen.Id(name).Add(base.Int().Add(tag)), nil
-	case "Rapid/Scalars/String":
+	case "Apia/Scalars/String", "Rapid/Scalars/String":
 		return jen.Id(name).Add(base.String().Add(tag)), nil
-	case "Rapid/Scalars/UnixTime":
+	case "Apia/Scalars/UnixTime", "Rapid/Scalars/UnixTime":
 		return jen.Id(name).Add(sliceBase.Id("*").Qual(
 			"github.com/augurysys/timestamp", "Timestamp",
 		)).Add(tag), nil


### PR DESCRIPTION
The underlying project that Katapult for it's API was renamed from Rapid to Apia
(and open-sourced). This changed some internal naming conventions in the schema
file produced by Katapult's API, which in turn broke codgen here in go-katapult,
due to the basic types living within the "Apia" top-level namespace instead of
"Rapid" as they used to.

This change makes codegen compatible with both old and new schema formats.