### PR TITLE
ci(github): remove benchmark CI tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,29 +58,6 @@ jobs:
       - name: Check if generate results are up to date
         run: make check-generate
 
-  benchmark:
-    name: Benchmarks
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.18"
-      - name: Run benchmarks
-        run: make bench | tee output.txt
-      - name: Announce benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: "go"
-          alert-threshold: "150%"
-          fail-threshold: "300%"
-          output-file-path: output.txt
-          fail-on-alert: true
-          comment-on-alert: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: false
-
   cov:
     name: Coverage
     runs-on: ubuntu-latest
@@ -132,23 +109,3 @@ jobs:
         run: make test
         env:
           VERBOSE: "true"
-
-  benchmark-store:
-    name: Store benchmarks
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.18"
-      - name: Run benchmarks
-        run: make bench | tee output.txt
-      - name: Store benchmark result
-        uses: rhysd/github-action-benchmark@v1
-        with:
-          tool: "go"
-          output-file-path: output.txt
-          github-token: ${{ secrets.GH_PUSH_TOKEN }}
-          comment-on-alert: true
-          auto-push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           key: ${{ runner.os }}-golangcilint-${{ hashFiles('**/Makefile') }}
           restore-keys: |
             ${{ runner.os }}-golangcilint-
-      - name: Check if mods are tidy
+      - name: Run make lint
         run: make lint
         env:
           GOLANGCILINTARGS: --out-format=github-actions


### PR DESCRIPTION
We don't really use them, as we've only got benchmarks in the namegenerator
package. And as of late, they're unreliable and fluctuate.