### PR TITLE
feat(core/SecurityGroupRule): add SecurityGroup ref field

### DIFF
--- a/core/security_group_rule.go
+++ b/core/security_group_rule.go
@@ -9,12 +9,13 @@ import (
 )
 
 type SecurityGroupRule struct {
-	ID        string   `json:"id,omitempty"`
-	Direction string   `json:"direction,omitempty"`
-	Protocol  string   `json:"protocol,omitempty"`
-	Ports     string   `json:"ports,omitempty"`
-	Targets   []string `json:"targets,omitempty"`
-	Notes     string   `json:"notes,omitempty"`
+	ID            string            `json:"id,omitempty"`
+	SecurityGroup *SecurityGroupRef `json:"security_group,omitempty"`
+	Direction     string            `json:"direction,omitempty"`
+	Protocol      string            `json:"protocol,omitempty"`
+	Ports         string            `json:"ports,omitempty"`
+	Targets       []string          `json:"targets,omitempty"`
+	Notes         string            `json:"notes,omitempty"`
 }
 
 func (sgr *SecurityGroupRule) Ref() SecurityGroupRuleRef {

--- a/core/security_group_rule_test.go
+++ b/core/security_group_rule_test.go
@@ -59,7 +59,7 @@ func TestSecurityGroupRuleRef_JSONMarshaling(t *testing.T) {
 		{
 			name: "full",
 			obj: &SecurityGroupRuleRef{
-				ID: "sg_3uXbmANw4sQiF1J3",
+				ID: "sgr_3uXbmANw4sQiF1J3",
 			},
 		},
 	}

--- a/core/security_group_rule_test.go
+++ b/core/security_group_rule_test.go
@@ -82,7 +82,10 @@ func TestSecurityGroupRule_JSONMarshalling(t *testing.T) {
 		{
 			name: "full",
 			obj: &SecurityGroupRule{
-				ID:        "arbitrary string",
+				ID: "arbitrary string",
+				SecurityGroup: &SecurityGroupRef{
+					ID: "sg_8cJxXwLSlzVrT32b",
+				},
 				Direction: "inbound",
 				Protocol:  "TCP",
 				Ports:     port,

--- a/core/testdata/TestSecurityGroupRuleRef_JSONMarshaling/full.golden
+++ b/core/testdata/TestSecurityGroupRuleRef_JSONMarshaling/full.golden
@@ -1,1 +1,1 @@
-{"id":"sg_3uXbmANw4sQiF1J3"}
+{"id":"sgr_3uXbmANw4sQiF1J3"}

--- a/core/testdata/TestSecurityGroupRule_JSONMarshalling/full.golden
+++ b/core/testdata/TestSecurityGroupRule_JSONMarshalling/full.golden
@@ -1,1 +1,1 @@
-{"id":"arbitrary string","direction":"inbound","protocol":"TCP","ports":"3000","targets":["192.168.0.1"],"notes":"My fave security group rule"}
+{"id":"arbitrary string","security_group":{"id":"sg_8cJxXwLSlzVrT32b"},"direction":"inbound","protocol":"TCP","ports":"3000","targets":["192.168.0.1"],"notes":"My fave security group rule"}


### PR DESCRIPTION
Without this, it was not possible to determine what Security Group a
rule belonged to when fetching a Rule by its ID.