### PR TITLE
fix(core): change return type of List() method on SecurityGroupRules and LoadBalancerRules

### DIFF
--- a/core/load_balancer_rule.go
+++ b/core/load_balancer_rule.go
@@ -78,7 +78,7 @@ type LoadBalancerRuleArguments struct {
 type loadBalancerRulesResponseBody struct {
 	Pagination        *katapult.Pagination `json:"pagination,omitempty"`
 	LoadBalancerRule  *LoadBalancerRule    `json:"load_balancer_rule,omitempty"`
-	LoadBalancerRules []LoadBalancerRule   `json:"load_balancer_rules,omitempty"`
+	LoadBalancerRules []*LoadBalancerRule  `json:"load_balancer_rules,omitempty"`
 }
 
 type LoadBalancerRulesClient struct {
@@ -101,7 +101,7 @@ func (s *LoadBalancerRulesClient) List(
 	lb LoadBalancerRef,
 	opts *ListOptions,
 	reqOpts ...katapult.RequestOption,
-) ([]LoadBalancerRule, *katapult.Response, error) {
+) ([]*LoadBalancerRule, *katapult.Response, error) {
 	qs := queryValues(opts, lb)
 	u := &url.URL{
 		Path:     "load_balancers/_/rules",

--- a/core/load_balancer_rule_test.go
+++ b/core/load_balancer_rule_test.go
@@ -147,7 +147,7 @@ func Test_loadBalancerRulesResponseBody_JSONMarshalling(t *testing.T) {
 					LargeSet: true,
 				},
 				LoadBalancerRule: &LoadBalancerRule{ID: "foobar"},
-				LoadBalancerRules: []LoadBalancerRule{
+				LoadBalancerRules: []*LoadBalancerRule{
 					{
 						ID: "barfoo",
 					},
@@ -228,7 +228,7 @@ func TestLoadBalancerRulesClient_List(t *testing.T) {
 		respErr  error
 		respV    *loadBalancerRulesResponseBody
 		wantReq  *katapult.Request
-		want     []LoadBalancerRule
+		want     []*LoadBalancerRule
 		wantResp *katapult.Response
 		wantErr  string
 	}{
@@ -247,7 +247,7 @@ func TestLoadBalancerRulesClient_List(t *testing.T) {
 			},
 			respV: &loadBalancerRulesResponseBody{
 				Pagination: &katapult.Pagination{Total: 394},
-				LoadBalancerRules: []LoadBalancerRule{
+				LoadBalancerRules: []*LoadBalancerRule{
 					{ID: "lbrule_3W0eRZLQYHpTCPNX", DestinationPort: 666},
 				},
 			},
@@ -264,7 +264,7 @@ func TestLoadBalancerRulesClient_List(t *testing.T) {
 					}.Encode(),
 				},
 			},
-			want: []LoadBalancerRule{{
+			want: []*LoadBalancerRule{{
 				ID:              "lbrule_3W0eRZLQYHpTCPNX",
 				DestinationPort: 666,
 			}},
@@ -285,7 +285,7 @@ func TestLoadBalancerRulesClient_List(t *testing.T) {
 			},
 			respV: &loadBalancerRulesResponseBody{
 				Pagination: &katapult.Pagination{Total: 333},
-				LoadBalancerRules: []LoadBalancerRule{
+				LoadBalancerRules: []*LoadBalancerRule{
 					{ID: "lbrule_3W0eRZLQYHpTCPNX", DestinationPort: 666},
 				},
 			},
@@ -300,7 +300,7 @@ func TestLoadBalancerRulesClient_List(t *testing.T) {
 					}.Encode(),
 				},
 			},
-			want: []LoadBalancerRule{{
+			want: []*LoadBalancerRule{{
 				ID:              "lbrule_3W0eRZLQYHpTCPNX",
 				DestinationPort: 666,
 			}},

--- a/core/security_group_rule.go
+++ b/core/security_group_rule.go
@@ -41,7 +41,7 @@ type SecurityGroupRuleArguments struct {
 type securityGroupRulesResponseBody struct {
 	Pagination         *katapult.Pagination `json:"pagination,omitempty"`
 	SecurityGroupRule  *SecurityGroupRule   `json:"security_group_rule,omitempty"`
-	SecurityGroupRules []SecurityGroupRule  `json:"security_group_rules,omitempty"`
+	SecurityGroupRules []*SecurityGroupRule `json:"security_group_rules,omitempty"`
 }
 
 type SecurityGroupRulesClient struct {
@@ -64,7 +64,7 @@ func (s *SecurityGroupRulesClient) List(
 	sg SecurityGroupRef,
 	opts *ListOptions,
 	reqOpts ...katapult.RequestOption,
-) ([]SecurityGroupRule, *katapult.Response, error) {
+) ([]*SecurityGroupRule, *katapult.Response, error) {
 	qs := queryValues(opts, sg)
 	u := &url.URL{
 		Path:     "security_groups/_/rules",

--- a/core/security_group_rule_test.go
+++ b/core/security_group_rule_test.go
@@ -164,7 +164,7 @@ func Test_securityGroupRulesResponseBody_JSONMarshalling(t *testing.T) {
 					LargeSet: true,
 				},
 				SecurityGroupRule: &SecurityGroupRule{ID: "foobar"},
-				SecurityGroupRules: []SecurityGroupRule{
+				SecurityGroupRules: []*SecurityGroupRule{
 					{
 						ID: "barfoo",
 					},
@@ -253,7 +253,7 @@ func TestSecurityGroupRulesClient_List(t *testing.T) {
 		respErr  error
 		respV    *securityGroupRulesResponseBody
 		wantReq  *katapult.Request
-		want     []SecurityGroupRule
+		want     []*SecurityGroupRule
 		wantResp *katapult.Response
 		wantErr  string
 	}{
@@ -272,7 +272,7 @@ func TestSecurityGroupRulesClient_List(t *testing.T) {
 			},
 			respV: &securityGroupRulesResponseBody{
 				Pagination: &katapult.Pagination{Total: 333},
-				SecurityGroupRules: []SecurityGroupRule{
+				SecurityGroupRules: []*SecurityGroupRule{
 					{ID: "sgr_WbCly1EHB3jNMQNC", Direction: "inbound"},
 				},
 			},
@@ -287,7 +287,7 @@ func TestSecurityGroupRulesClient_List(t *testing.T) {
 					}.Encode(),
 				},
 			},
-			want: []SecurityGroupRule{
+			want: []*SecurityGroupRule{
 				{ID: "sgr_WbCly1EHB3jNMQNC", Direction: "inbound"},
 			},
 			wantResp: &katapult.Response{
@@ -307,7 +307,7 @@ func TestSecurityGroupRulesClient_List(t *testing.T) {
 			},
 			respV: &securityGroupRulesResponseBody{
 				Pagination: &katapult.Pagination{Total: 124},
-				SecurityGroupRules: []SecurityGroupRule{
+				SecurityGroupRules: []*SecurityGroupRule{
 					{ID: "sgr_WbCly1EHB3jNMQNC", Direction: "inbound"},
 				},
 			},
@@ -320,7 +320,7 @@ func TestSecurityGroupRulesClient_List(t *testing.T) {
 					}.Encode(),
 				},
 			},
-			want: []SecurityGroupRule{
+			want: []*SecurityGroupRule{
 				{ID: "sgr_WbCly1EHB3jNMQNC", Direction: "inbound"},
 			},
 			wantResp: &katapult.Response{


### PR DESCRIPTION
They previously returned a slice of concrete types rather than a slice of
pointer types like all other List() methods we have. Hence this is worth it for
the sake of consistency, despite it being a breaking change.