### PR TITLE
feat(load-balancer-rule): add backend + passthrough SSL

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - durationcheck
     - errcheck
     - errorlint

--- a/buildspec/buildspec_test.go
+++ b/buildspec/buildspec_test.go
@@ -25,7 +25,7 @@ type badWriter struct {
 	err error
 }
 
-func (s *badWriter) Write(p []byte) (int, error) {
+func (s *badWriter) Write(_ []byte) (int, error) {
 	return 0, s.err
 }
 

--- a/core/load_balancer_rule.go
+++ b/core/load_balancer_rule.go
@@ -74,6 +74,8 @@ type LoadBalancerRuleArguments struct {
 	ListenPort        int                       `json:"listen_port,omitempty"`
 	Protocol          Protocol                  `json:"protocol,omitempty"`
 	ProxyProtocol     *bool                     `json:"proxy_protocol,omitempty"`
+	BackendSSL        *bool                     `json:"backend_ssl,omitempty"`
+	PassthroughSSL    *bool                     `json:"passthrough_ssl,omitempty"`
 	Certificates      *[]CertificateRef         `json:"certificates,omitempty"`
 	CheckEnabled      *bool                     `json:"check_enabled,omitempty"`
 	CheckFall         int                       `json:"check_fall,omitempty"`

--- a/core/load_balancer_rule_test.go
+++ b/core/load_balancer_rule_test.go
@@ -108,6 +108,8 @@ func TestLoadBalancerRuleArguments_JSONMarshalling(t *testing.T) {
 						ID: "another abitrary string",
 					},
 				},
+				BackendSSL:        boolPtr(true),
+				PassthroughSSL:    boolPtr(true),
 				CheckEnabled:      boolPtr(false),
 				CheckFall:         3,
 				CheckInterval:     50,

--- a/core/load_balancer_rule_test.go
+++ b/core/load_balancer_rule_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func ptr[T any](x T) *T { return &x }
-
 func TestClient_LoadBalancerRules(t *testing.T) {
 	c := New(&testclient.Client{})
 
@@ -765,8 +763,8 @@ func TestLoadBalancerRulesClient_Update(t *testing.T) {
 				ref: LoadBalancerRuleRef{ID: "lbrule_GDPBAqW3dm71i4ol"},
 				args: &LoadBalancerRuleArguments{
 					DestinationPort: 3000,
-					BackendSSL:      ptr(true),
-					PassthroughSSL:  ptr(true),
+					BackendSSL:      boolPtr(true),
+					PassthroughSSL:  boolPtr(true),
 				},
 			},
 			resp: &katapult.Response{
@@ -795,8 +793,8 @@ func TestLoadBalancerRulesClient_Update(t *testing.T) {
 				Body: &loadBalancerRuleUpdateRequest{
 					Properties: &LoadBalancerRuleArguments{
 						DestinationPort: 3000,
-						BackendSSL:      ptr(true),
-						PassthroughSSL:  ptr(true),
+						BackendSSL:      boolPtr(true),
+						PassthroughSSL:  boolPtr(true),
 					},
 				},
 			},

--- a/core/load_balancer_rule_test.go
+++ b/core/load_balancer_rule_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func ptr[T any](x T) *T { return &x }
+
 func TestClient_LoadBalancerRules(t *testing.T) {
 	c := New(&testclient.Client{})
 
@@ -759,9 +761,13 @@ func TestLoadBalancerRulesClient_Update(t *testing.T) {
 		{
 			name: "success",
 			args: args{
-				ctx:  context.Background(),
-				ref:  LoadBalancerRuleRef{ID: "lbrule_GDPBAqW3dm71i4ol"},
-				args: &LoadBalancerRuleArguments{DestinationPort: 3000},
+				ctx: context.Background(),
+				ref: LoadBalancerRuleRef{ID: "lbrule_GDPBAqW3dm71i4ol"},
+				args: &LoadBalancerRuleArguments{
+					DestinationPort: 3000,
+					BackendSSL:      ptr(true),
+					PassthroughSSL:  ptr(true),
+				},
 			},
 			resp: &katapult.Response{
 				Response: &http.Response{StatusCode: http.StatusOK},
@@ -772,6 +778,8 @@ func TestLoadBalancerRulesClient_Update(t *testing.T) {
 					DestinationPort: 3000,
 					ListenPort:      80,
 					Protocol:        HTTPProtocol,
+					BackendSSL:      true,
+					PassthroughSSL:  true,
 				},
 			},
 			wantReq: &katapult.Request{
@@ -787,6 +795,8 @@ func TestLoadBalancerRulesClient_Update(t *testing.T) {
 				Body: &loadBalancerRuleUpdateRequest{
 					Properties: &LoadBalancerRuleArguments{
 						DestinationPort: 3000,
+						BackendSSL:      ptr(true),
+						PassthroughSSL:  ptr(true),
 					},
 				},
 			},
@@ -795,6 +805,8 @@ func TestLoadBalancerRulesClient_Update(t *testing.T) {
 				DestinationPort: 3000,
 				ListenPort:      80,
 				Protocol:        HTTPProtocol,
+				BackendSSL:      true,
+				PassthroughSSL:  true,
 			},
 			wantResp: &katapult.Response{
 				Response: &http.Response{StatusCode: http.StatusOK},

--- a/core/testdata/TestLoadBalancerRuleArguments_JSONMarshalling/full.golden
+++ b/core/testdata/TestLoadBalancerRuleArguments_JSONMarshalling/full.golden
@@ -4,6 +4,8 @@
   "listen_port": 1337,
   "protocol": "HTTP",
   "proxy_protocol": false,
+  "backend_ssl": true,
+  "passthrough_ssl": true,
   "certificates": [
     {
       "id": "another abitrary string"

--- a/katapult_test.go
+++ b/katapult_test.go
@@ -24,7 +24,7 @@ type testErrorWriter struct {
 	err error
 }
 
-func (s *testErrorWriter) Write(p []byte) (int, error) {
+func (s *testErrorWriter) Write(_ []byte) (int, error) {
 	return 0, s.err
 }
 
@@ -32,7 +32,7 @@ type testErrorHTTPClient struct {
 	err error
 }
 
-func (s *testErrorHTTPClient) Do(req *http.Request) (*http.Response, error) {
+func (s *testErrorHTTPClient) Do(_ *http.Request) (*http.Response, error) {
 	return nil, s.err
 }
 


### PR DESCRIPTION
Included in this PR: 
* Introduces `BackendSSL` and `PassthroughSSL` to the `LoadBalancerRuleArguments` type.
* Removal of `depguard` linter
* `_` of remaining `unused` params highlighted by lint warnings.
