### PR TITLE
feat(core/virtual-machine): add new "allocating" and "allocated" states

### DIFF
--- a/core/virtual_machine.go
+++ b/core/virtual_machine.go
@@ -54,6 +54,8 @@ type VirtualMachineState string
 const (
 	VirtualMachineStopped      VirtualMachineState = "stopped"
 	VirtualMachineFailed       VirtualMachineState = "failed"
+	VirtualMachineAllocating   VirtualMachineState = "allocating"
+	VirtualMachineAllocated    VirtualMachineState = "allocated"
 	VirtualMachineStarted      VirtualMachineState = "started"
 	VirtualMachineStarting     VirtualMachineState = "starting"
 	VirtualMachineResetting    VirtualMachineState = "resetting"

--- a/core/virtual_machine_test.go
+++ b/core/virtual_machine_test.go
@@ -153,6 +153,16 @@ func TestVirtualMachineStates(t *testing.T) {
 			value: "failed",
 		},
 		{
+			name:  "VirtualMachineAllocating",
+			enum:  VirtualMachineAllocating,
+			value: "allocating",
+		},
+		{
+			name:  "VirtualMachineAllocated",
+			enum:  VirtualMachineAllocated,
+			value: "allocated",
+		},
+		{
 			name:  "VirtualMachineStarted",
 			enum:  VirtualMachineStarted,
 			value: "started",


### PR DESCRIPTION
This add constants for two new possible VM states which each VM briefly
transitions through during start up.