### PR TITLE
ci(nightly): fix go version so workflow works

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - name: Check if bundled schemas are up to date
         run: make check-schemas


### PR DESCRIPTION
The `1.20` integer value was being interpreted as Go 1.2.x, not 1.20.x.