### PR TITLE
feat(next): update generated core and public clients from Katapult 2.68.0 schemas

### DIFF
--- a/next/client.go
+++ b/next/client.go
@@ -7,6 +7,8 @@ import (
 	"github.com/krystal/go-katapult/next/public"
 )
 
+//go:generate ./generate.sh
+
 type Client struct {
 	Core   core.ClientInterface
 	Public public.ClientInterface

--- a/next/core/core.go
+++ b/next/core/core.go
@@ -52,6 +52,11 @@ const (
 	CertificateStateEnumPending     CertificateStateEnum = "pending"
 )
 
+// Defines values for ContinuousManagementDisabledEnum.
+const (
+	ContinuousManagementDisabled ContinuousManagementDisabledEnum = "continuous_management_disabled"
+)
+
 // Defines values for CountryNotFoundEnum.
 const (
 	CountryNotFound CountryNotFoundEnum = "country_not_found"
@@ -920,6 +925,9 @@ type CertificateNotFoundEnum string
 // CertificateStateEnum defines model for CertificateStateEnum.
 type CertificateStateEnum string
 
+// ContinuousManagementDisabledEnum defines model for ContinuousManagementDisabledEnum.
+type ContinuousManagementDisabledEnum string
+
 // Country defines model for Country.
 type Country struct {
 	Eu       *bool                     `json:"eu,omitempty"`
@@ -1636,9 +1644,12 @@ type GetDataCenter200ResponseDataCenter struct {
 // GetDataCenterDefaultNetwork200ResponseNetwork defines model for GetDataCenterDefaultNetwork200ResponseNetwork.
 type GetDataCenterDefaultNetwork200ResponseNetwork struct {
 	DataCenter *GetDataCenterDefaultNetworkPartDataCenter `json:"data_center,omitempty"`
-	Id         *string                                    `json:"id,omitempty"`
-	Name       *string                                    `json:"name,omitempty"`
-	Permalink  nullable.Nullable[string]                  `json:"permalink,omitempty"`
+
+	// Default Indicates if this network is the default network for the data center.
+	Default   *bool                     `json:"default,omitempty"`
+	Id        *string                   `json:"id,omitempty"`
+	Name      *string                   `json:"name,omitempty"`
+	Permalink nullable.Nullable[string] `json:"permalink,omitempty"`
 }
 
 // GetDataCenterDefaultNetworkPartDataCenter defines model for GetDataCenterDefaultNetworkPartDataCenter.
@@ -1971,9 +1982,12 @@ type GetOrganizationAddressLists200ResponseAddressLists struct {
 // GetOrganizationAvailableNetworks200ResponseNetworks defines model for GetOrganizationAvailableNetworks200ResponseNetworks.
 type GetOrganizationAvailableNetworks200ResponseNetworks struct {
 	DataCenter *GetOrganizationAvailableNetworksPartDataCenter `json:"data_center,omitempty"`
-	Id         *string                                         `json:"id,omitempty"`
-	Name       *string                                         `json:"name,omitempty"`
-	Permalink  nullable.Nullable[string]                       `json:"permalink,omitempty"`
+
+	// Default Indicates if this network is the default network for the data center.
+	Default   *bool                     `json:"default,omitempty"`
+	Id        *string                   `json:"id,omitempty"`
+	Name      *string                   `json:"name,omitempty"`
+	Permalink nullable.Nullable[string] `json:"permalink,omitempty"`
 }
 
 // GetOrganizationAvailableNetworks200ResponseVirtualNetworks defines model for GetOrganizationAvailableNetworks200ResponseVirtualNetworks.
@@ -2705,10 +2719,13 @@ type MultipleObjectStorageBucketsFoundEnum string
 
 // Network defines model for Network.
 type Network struct {
-	DataCenter *DataCenter               `json:"data_center,omitempty"`
-	Id         *string                   `json:"id,omitempty"`
-	Name       *string                   `json:"name,omitempty"`
-	Permalink  nullable.Nullable[string] `json:"permalink,omitempty"`
+	DataCenter *DataCenter `json:"data_center,omitempty"`
+
+	// Default Indicates if this network is the default network for the data center.
+	Default   *bool                     `json:"default,omitempty"`
+	Id        *string                   `json:"id,omitempty"`
+	Name      *string                   `json:"name,omitempty"`
+	Permalink nullable.Nullable[string] `json:"permalink,omitempty"`
 }
 
 // NetworkErrorEnum defines model for NetworkErrorEnum.
@@ -5024,6 +5041,13 @@ type CertificateNotFoundResponse struct {
 	Code        *CertificateNotFoundEnum `json:"code,omitempty"`
 	Description *string                  `json:"description,omitempty"`
 	Detail      *map[string]interface{}  `json:"detail,omitempty"`
+}
+
+// ContinuousManagementDisabledResponse defines model for ContinuousManagementDisabledResponse.
+type ContinuousManagementDisabledResponse struct {
+	Code        *ContinuousManagementDisabledEnum `json:"code,omitempty"`
+	Description *string                           `json:"description,omitempty"`
+	Detail      *map[string]interface{}           `json:"detail,omitempty"`
 }
 
 // CountryNotFoundResponse defines model for CountryNotFoundResponse.
@@ -31896,6 +31920,7 @@ type GetVirtualMachineAuthorizedKeysResponse struct {
 	JSON400      *APIAuthenticator400Response
 	JSON403      *APIAuthenticator403Response
 	JSON404      *NoVirtualMachineForAPITokenResponse
+	JSON409      *ContinuousManagementDisabledResponse
 	JSON429      *APIAuthenticator429Response
 	JSON503      *APIAuthenticator503Response
 }
@@ -50065,6 +50090,13 @@ func ParseGetVirtualMachineAuthorizedKeysResponse(rsp *http.Response) (*GetVirtu
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ContinuousManagementDisabledResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 429:
 		var dest APIAuthenticator429Response

--- a/next/generate.sh
+++ b/next/generate.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
+echo "Generating Core and Public clients using OpenAPI specs"
 
-go_version=$(grep goVersion generator-config.yml | cut -d':' -f2 | tr -d '[:space:]')
-generator_version=$(grep generatorVersion generator-config.yml | cut -d':' -f2 | tr -d '[:space:]')
+go_version="$(grep goVersion generator-config.yml | cut -d':' -f2 | tr -d '[:space:]')"
+generator_version="$(grep generatorVersion generator-config.yml | cut -d':' -f2 | tr -d '[:space:]')"
+core_api_version="$(jq -r '.info."x-katapult-version"' katapult-core-openapi.json)"
+public_api_version="$(jq -r '.info."x-katapult-version"' katapult-public-openapi.json)"
 
+echo " -> Using Go version: $go_version"
+echo " -> Using OpenAPI generator version: $generator_version"
+
+echo " -> Generating Core client (Katapult version: ${core_api_version})..."
 docker run \
   --user "$(id -u):$(id -g)" \
   -v "$(pwd):/local" \
@@ -12,8 +19,9 @@ docker run \
   -generate types,client \
   -package core \
   -templates /local/templates \
-   /local/katapult-core-openapi.json > "./core/core.go" 
+  /local/katapult-core-openapi.json > "./core/core.go"
 
+echo " -> Generating Public client (Katapult version: ${public_api_version})..."
 docker run \
   --user "$(id -u):$(id -g)" \
   -v "$(pwd):/local" \
@@ -22,4 +30,4 @@ docker run \
   -generate types,client \
   -package public \
   -templates /local/templates \
-   /local/katapult-public-openapi.json > "./public/public.go" 
+  /local/katapult-public-openapi.json > "./public/public.go"

--- a/next/katapult-core-openapi.json
+++ b/next/katapult-core-openapi.json
@@ -1,14 +1,14 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "x-katapult-version": "2.64.0",
+    "x-katapult-version": "2.68.0",
     "version": "1.0.0",
     "title": "Katapult Core API",
     "description": "Welcome to the documentation for the Katapult Core API"
   },
   "externalDocs": {
     "description": "Katapult API Documentation",
-    "url": "https://developers.katapult.io/docs/category/core-api"
+    "url": "https://docs.katapult.io/docs/category/core-api"
   },
   "servers": [
     {
@@ -15943,6 +15943,9 @@
           "404": {
             "$ref": "#/components/responses/NoVirtualMachineForAPITokenResponse"
           },
+          "409": {
+            "$ref": "#/components/responses/ContinuousManagementDisabledResponse"
+          },
           "429": {
             "$ref": "#/components/responses/APIAuthenticator429Response"
           },
@@ -16299,6 +16302,10 @@
           "permalink": {
             "type": "string",
             "nullable": true
+          },
+          "default": {
+            "type": "boolean",
+            "description": "Indicates if this network is the default network for the data center."
           },
           "data_center": {
             "$ref": "#/components/schemas/GetDataCenterDefaultNetworkPartDataCenter"
@@ -19976,6 +19983,10 @@
             "type": "string",
             "nullable": true
           },
+          "default": {
+            "type": "boolean",
+            "description": "Indicates if this network is the default network for the data center."
+          },
           "data_center": {
             "$ref": "#/components/schemas/DataCenter"
           }
@@ -20516,6 +20527,12 @@
         "type": "string",
         "enum": [
           "no_virtual_machine_for_api_token"
+        ]
+      },
+      "ContinuousManagementDisabledEnum": {
+        "type": "string",
+        "enum": [
+          "continuous_management_disabled"
         ]
       },
       "ZoneLookup": {
@@ -22954,6 +22971,10 @@
           "permalink": {
             "type": "string",
             "nullable": true
+          },
+          "default": {
+            "type": "boolean",
+            "description": "Indicates if this network is the default network for the data center."
           },
           "data_center": {
             "$ref": "#/components/schemas/GetOrganizationAvailableNetworksPartDataCenter"
@@ -26701,6 +26722,26 @@
               "properties": {
                 "code": {
                   "$ref": "#/components/schemas/NoVirtualMachineForAPITokenEnum"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "detail": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ContinuousManagementDisabledResponse": {
+        "description": "SSH Key Continuous management is not enabled for this virtual machine",
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "code": {
+                  "$ref": "#/components/schemas/ContinuousManagementDisabledEnum"
                 },
                 "description": {
                   "type": "string"

--- a/next/katapult-public-openapi.json
+++ b/next/katapult-public-openapi.json
@@ -1,14 +1,14 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "x-katapult-version": "2.64.0",
+    "x-katapult-version": "2.68.0",
     "version": "1.0.0",
     "title": "Katapult Public API",
     "description": "Welcome to the documentation for the Katapult Public API"
   },
   "externalDocs": {
     "description": "Katapult API Documentation",
-    "url": "https://developers.katapult.io/docs/category/public-api"
+    "url": "https://docs.katapult.io/docs/category/public-api"
   },
   "servers": [
     {


### PR DESCRIPTION
Also update the generate.sh script to print some basic information about what it is doing.